### PR TITLE
fix: typograpf ru phone mask

### DIFF
--- a/src/text-transform/utils.ts
+++ b/src/text-transform/utils.ts
@@ -27,7 +27,7 @@ export const DEFAULT_ALLOWED_TAGS = [
 ];
 export const typografConfig = {
     enabled: ['common/nbsp/afterNumber', 'common/nbsp/afterParagraphMark'],
-    disabled: ['common/symbols/cf'],
+    disabled: ['common/symbols/cf', 'ru/other/phone-number'],
 };
 export const sanitizeStripOptions: sanitize.IOptions = {
     allowedTags: [],


### PR DESCRIPTION
There are no rules for a phone mask in english, there are in russian and it works strangely. In russian it can turns out +7 (800-80) 0-11-11