### PR TITLE
fix: monochrome button theme

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -3,12 +3,12 @@
 $block: '.#{$ns}button-block';
 
 @mixin monochromeButton() {
-    --yc-button-background-color: var(--pc-monochrome-button);
-    --yc-button-background-color-hover: var(--pc-monochrome-button-hover);
-    color: var(--yc-color-text-light-primary);
+    --yc-button-background-color: var(--pc-monochrome-button-background-color);
+    --yc-button-background-color-hover: var(--pc-monochrome-button-background-color-hover);
+    color: var(--pc-monochrome-button-color);
 
     &:hover {
-        color: var(--yc-color-text-light-primary);
+        color: var(--pc-monochrome-button-color);
     }
 }
 

--- a/src/sub-blocks/Content/Content.scss
+++ b/src/sub-blocks/Content/Content.scss
@@ -18,6 +18,10 @@ $darkSecondary: var(--yc-color-text-dark-secondary);
 }
 
 #{$block} {
+    --pc-monochrome-button-background-color: #262626;
+    --pc-monochrome-button-background-color-hover: #393939;
+    --pc-monochrome-button-color: var(--yc-color-text-light-primary);
+
     &__notice,
     &__text {
         .yfm ol,

--- a/styles/root.scss
+++ b/styles/root.scss
@@ -13,13 +13,17 @@
     --pc-color-sfx-shadow: var(--yc-color-base-simple-hover);
     --pc-color-line-generic-active-solid: #b3b3b3;
     --pc-color-base-float-hover: var(--yc-color-base-float);
-    --pc-monochrome-button: #262626;
-    --pc-monochrome-button-hover: #393939;
+    --pc-monochrome-button-background-color: #262626;
+    --pc-monochrome-button-background-color-hover: #393939;
+    --pc-monochrome-button-color: var(--yc-color-text-light-primary);
     --pc-text-header-color: var(--yc-color-text-primary);
 
     &.yc-root_theme_dark {
         --pc-color-sfx-shadow: var(--yc-color-sfx-shadow);
         --pc-color-line-generic-active-solid: #6c6c70;
         --pc-color-base-float-hover: var(--yc-color-base-float-hover);
+        --pc-monochrome-button-background-color: #ffffff;
+        --pc-monochrome-button-background-color-hover: #e9e9e9;
+        --pc-monochrome-button-color: var(--yc-color-text-dark-primary);
     }
 }


### PR DESCRIPTION
- Tabs in the dark theme has to have white button instead of black 
https://preview.yandexcloud.dev/page-constructor/89/?path=/story/blocks-tabs--default&globals=theme:dark;backgrounds.value:black;background:dark

- Content block (monochrome kight) in the dark theme has to have black button as in the light theme
https://preview.yandexcloud.dev/page-constructor/89/?path=/story/blocks-contentlayout--theme&globals=theme:dark;backgrounds.value:black;background:dark