### PR TITLE
fix: cannot read stopPropagation of undefined in navigation utils

### DIFF
--- a/src/navigation/utils.ts
+++ b/src/navigation/utils.ts
@@ -16,6 +16,8 @@ export const getItemClickHandler: ({
     ({column, index, onActiveItemChange, activeItemId}) =>
     (e) => {
         const id = `${column}-${index}`;
-        e.stopPropagation();
+        if (e) {
+            e.stopPropagation();
+        }
         onActiveItemChange(id === activeItemId ? undefined : `${column}-${index}`);
     };


### PR DESCRIPTION
We can see this problem if we use `button` in rightItems in navigation and use Link from LocationContext