### PR TITLE
feat: add custom indent for all blocks, and add className prop for CardLayoutBlock

### DIFF
--- a/.storybook/stories/documentation/Blocks.mdx
+++ b/.storybook/stories/documentation/Blocks.mdx
@@ -14,7 +14,11 @@ Each block has the following common properties:
 
 `visible?: 'all' | 'sm' | 'md' | 'lg' | 'xl'` — Sets the screen size to start block display from
 
-`resetPaddings: boolean` — Allows resetting top and bottom margins standard for all blocks
+`resetPaddings: boolean` — Allows resetting top and bottom margins standard for all blocks. **Deprecated**, use `indentTop, indentBottom` instead
+
+`indentTop` - block indentation at the top, default size `l`, examples you can see [here](?path=/story/blocks-cardlayout--with-custom-indents)
+
+`indentBottom` - block indentation at the bottom, default size `l`, examples you can see [here](?path=/story/blocks-cardlayout--with-custom-indents)
 
 _[Common field types](?id=information--common-types&viewMode=docs)_
 

--- a/.storybook/stories/documentation/Blocks.mdx
+++ b/.storybook/stories/documentation/Blocks.mdx
@@ -14,11 +14,12 @@ Each block has the following common properties:
 
 `visible?: 'all' | 'sm' | 'md' | 'lg' | 'xl'` — Sets the screen size to start block display from
 
-`resetPaddings: boolean` — Allows resetting top and bottom margins standard for all blocks. **Deprecated**, use `indentTop, indentBottom` instead
+`resetPaddings: boolean` — Allows resetting top and bottom margins standard for all blocks. **Deprecated**, use `indent` instead
 
-`indentTop` - block indentation at the top, default size `l`, examples you can see [here](?path=/story/blocks-cardlayout--with-custom-indents)
-
-`indentBottom` - block indentation at the bottom, default size `l`, examples you can see [here](?path=/story/blocks-cardlayout--with-custom-indents)
+`indent?: {
+  top?: string
+  bottom?: string
+}` - block indentation at the top and bottom, default size `l`, examples you can see [here](?path=/story/blocks-cardlayout--with-custom-indents)
 
 _[Common field types](?id=information--common-types&viewMode=docs)_
 

--- a/src/blocks/CardLayout/CardLayout.tsx
+++ b/src/blocks/CardLayout/CardLayout.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 
 import {AnimateBlock, Title} from '../../components';
 import {Col, GridColumnSizesType, Row} from '../../grid';
-import {CardLayoutBlockProps as CardLayoutBlockParams, WithChildren} from '../../models';
+import {
+    CardLayoutBlockProps as CardLayoutBlockParams,
+    ClassNameProps,
+    WithChildren,
+} from '../../models';
 import {block} from '../../utils';
 
 import './CardLayout.scss';
@@ -12,7 +16,8 @@ const DEFAULT_SIZES: GridColumnSizesType = {
     sm: 6,
     md: 4,
 };
-export type CardLayoutBlockProps = WithChildren<Omit<CardLayoutBlockParams, 'children'>>;
+export type CardLayoutBlockProps = WithChildren<Omit<CardLayoutBlockParams, 'children'>> &
+    ClassNameProps;
 
 const b = block('card-layout-block');
 
@@ -22,8 +27,9 @@ const CardLayout: React.FC<CardLayoutBlockProps> = ({
     animated,
     colSizes = DEFAULT_SIZES,
     children,
+    className,
 }) => (
-    <AnimateBlock className={b()} animate={animated}>
+    <AnimateBlock className={b(null, className)} animate={animated}>
         {(title || description) && <Title title={title} subtitle={description} />}
         <Row>
             {React.Children.map(children, (child, index) => (

--- a/src/blocks/CardLayout/__stories__/CardLayout.stories.tsx
+++ b/src/blocks/CardLayout/__stories__/CardLayout.stories.tsx
@@ -50,9 +50,56 @@ const ColSizeTemplate: StoryFn<CardLayoutBlockModel> = (args) => (
     </Fragment>
 );
 
+const WithCustomIndentsTemplate: StoryFn<CardLayoutBlockModel> = ({title, ...restArgs}) => (
+    <Fragment>
+        <PageConstructor
+            content={{
+                blocks: [
+                    {
+                        ...restArgs,
+                        title: `${title} with zero indents at the top and bottom`,
+                        indentTop: '0',
+                        indentBottom: '0',
+                    },
+                    {
+                        ...restArgs,
+                        title: `${title} with XS indents at the top and bottom`,
+                        indentTop: 'xs',
+                        indentBottom: 'xs',
+                    },
+                    {
+                        ...restArgs,
+                        title: `${title} with S indents at the top and bottom`,
+                        indentTop: 's',
+                        indentBottom: 's',
+                    },
+                    {
+                        ...restArgs,
+                        title: `${title} with M indents at the top and bottom`,
+                        indentTop: 'm',
+                        indentBottom: 'm',
+                    },
+                    {
+                        ...restArgs,
+                        title: `${title} with L (default) indents at the top and bottom`,
+                        indentTop: 'l',
+                        indentBottom: 'l',
+                    },
+                    {
+                        ...restArgs,
+                        title: `${title} with XL indents at the top and bottom`,
+                        indentTop: 'xl',
+                        indentBottom: 'xl',
+                    },
+                ],
+            }}
+        />
+    </Fragment>
+);
+
 export const Default = DefaultTemplate.bind({});
 export const ColSize = ColSizeTemplate.bind({});
-export const WithCustomIndent = DefaultTemplate.bind({});
+export const WithCustomIndents = WithCustomIndentsTemplate.bind({});
 
 Default.args = {
     ...data.default.content,
@@ -64,8 +111,7 @@ ColSize.args = {
     children: createCardArray(8, data.colSizes.four.card),
 } as CardLayoutBlockProps;
 
-WithCustomIndent.args = {
+WithCustomIndents.args = {
     ...data.default.content,
-    children: createCardArray(6, data.default.card),
-    indent: data.default.content.indent,
+    children: createCardArray(3, data.default.card),
 } as CardLayoutBlockProps;

--- a/src/blocks/CardLayout/__stories__/CardLayout.stories.tsx
+++ b/src/blocks/CardLayout/__stories__/CardLayout.stories.tsx
@@ -58,38 +58,50 @@ const WithCustomIndentsTemplate: StoryFn<CardLayoutBlockModel> = ({title, ...res
                     {
                         ...restArgs,
                         title: `${title} with zero indents at the top and bottom`,
-                        indentTop: '0',
-                        indentBottom: '0',
+                        indent: {
+                            top: '0',
+                            bottom: '0',
+                        },
                     },
                     {
                         ...restArgs,
                         title: `${title} with XS indents at the top and bottom`,
-                        indentTop: 'xs',
-                        indentBottom: 'xs',
+                        indent: {
+                            top: 'xs',
+                            bottom: 'xs',
+                        },
                     },
                     {
                         ...restArgs,
                         title: `${title} with S indents at the top and bottom`,
-                        indentTop: 's',
-                        indentBottom: 's',
+                        indent: {
+                            top: 's',
+                            bottom: 's',
+                        },
                     },
                     {
                         ...restArgs,
                         title: `${title} with M indents at the top and bottom`,
-                        indentTop: 'm',
-                        indentBottom: 'm',
+                        indent: {
+                            top: 'm',
+                            bottom: 'm',
+                        },
                     },
                     {
                         ...restArgs,
                         title: `${title} with L (default) indents at the top and bottom`,
-                        indentTop: 'l',
-                        indentBottom: 'l',
+                        indent: {
+                            top: 'l',
+                            bottom: 'l',
+                        },
                     },
                     {
                         ...restArgs,
                         title: `${title} with XL indents at the top and bottom`,
-                        indentTop: 'xl',
-                        indentBottom: 'xl',
+                        indent: {
+                            top: 'xl',
+                            bottom: 'xl',
+                        },
                     },
                 ],
             }}

--- a/src/blocks/CardLayout/__stories__/CardLayout.stories.tsx
+++ b/src/blocks/CardLayout/__stories__/CardLayout.stories.tsx
@@ -52,6 +52,7 @@ const ColSizeTemplate: StoryFn<CardLayoutBlockModel> = (args) => (
 
 export const Default = DefaultTemplate.bind({});
 export const ColSize = ColSizeTemplate.bind({});
+export const WithCustomIndent = DefaultTemplate.bind({});
 
 Default.args = {
     ...data.default.content,
@@ -61,4 +62,10 @@ Default.args = {
 ColSize.args = {
     ...data.default.content,
     children: createCardArray(8, data.colSizes.four.card),
+} as CardLayoutBlockProps;
+
+WithCustomIndent.args = {
+    ...data.default.content,
+    children: createCardArray(6, data.default.card),
+    indent: data.default.content.indent,
 } as CardLayoutBlockProps;

--- a/src/blocks/CardLayout/__stories__/data.json
+++ b/src/blocks/CardLayout/__stories__/data.json
@@ -13,7 +13,8 @@
     "content": {
       "type": "card-layout-block",
       "title": "Card Layout",
-      "description": "Three cards in a row on the desktop, two cards in a row on a tablet, one card in a row on a mobile phone."
+      "description": "Three cards in a row on the desktop, two cards in a row on a tablet, one card in a row on a mobile phone.",
+      "indent": "4xl"
     }
   },
   "colSizes": {

--- a/src/blocks/CardLayout/__stories__/data.json
+++ b/src/blocks/CardLayout/__stories__/data.json
@@ -13,8 +13,7 @@
     "content": {
       "type": "card-layout-block",
       "title": "Card Layout",
-      "description": "Three cards in a row on the desktop, two cards in a row on a tablet, one card in a row on a mobile phone.",
-      "indent": "4xl"
+      "description": "Three cards in a row on the desktop, two cards in a row on a tablet, one card in a row on a mobile phone."
     }
   },
   "colSizes": {

--- a/src/blocks/FilterBlock/FilterBlock.scss
+++ b/src/blocks/FilterBlock/FilterBlock.scss
@@ -21,6 +21,7 @@ $innerBlock: '.#{$ns}block-base';
         margin: 0px;
     }
 
+    // @deprecated
     --pc-first-block-indent: 0;
     --pc-first-block-mobile-indent: 0;
 }

--- a/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.scss
+++ b/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.scss
@@ -8,50 +8,26 @@ $block: '.#{$ns}constructor-block';
         &_indentTop {
             &_0 {
                 margin-top: 0;
-
-                &:first-child {
-                    margin-top: 0;
-                }
             }
 
             &_xs {
                 margin-top: $indentXS;
-
-                &:first-child {
-                    margin-top: $indentXS;
-                }
             }
 
             &_s {
                 margin-top: $indentSM;
-
-                &:first-child {
-                    margin-top: $indentSM;
-                }
             }
 
             &_m {
                 margin-top: $indentM;
-
-                &:first-child {
-                    margin-top: $indentM;
-                }
             }
 
             &_l {
                 margin-top: $indentL;
-
-                &:first-child {
-                    margin-top: $indentL;
-                }
             }
 
             &_xl {
                 margin-top: $indentXL;
-
-                &:first-child {
-                    margin-top: $indentXL;
-                }
             }
         }
 

--- a/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.scss
+++ b/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.scss
@@ -5,28 +5,17 @@ $block: '.#{$ns}constructor-block';
 
 #{$block} {
     @include add-specificity(&) {
-        &_indent {
-            &_xxxs {
-                margin-top: $indentXXXS;
-                padding-bottom: $indentXXXS;
+        &_indentTop {
+            &_0 {
+                margin-top: 0;
 
                 &:first-child {
-                    margin-top: $indentXXXS;
-                }
-            }
-
-            &_xxs {
-                margin-top: $indentXXS;
-                padding-bottom: $indentXXS;
-
-                &:first-child {
-                    margin-top: $indentXXS;
+                    margin-top: 0;
                 }
             }
 
             &_xs {
                 margin-top: $indentXS;
-                padding-bottom: $indentXS;
 
                 &:first-child {
                     margin-top: $indentXS;
@@ -34,17 +23,7 @@ $block: '.#{$ns}constructor-block';
             }
 
             &_s {
-                margin-top: $indentS;
-                padding-bottom: $indentS;
-
-                &:first-child {
-                    margin-top: $indentS;
-                }
-            }
-
-            &_sm {
                 margin-top: $indentSM;
-                padding-bottom: $indentSM;
 
                 &:first-child {
                     margin-top: $indentSM;
@@ -53,7 +32,6 @@ $block: '.#{$ns}constructor-block';
 
             &_m {
                 margin-top: $indentM;
-                padding-bottom: $indentM;
 
                 &:first-child {
                     margin-top: $indentM;
@@ -62,7 +40,6 @@ $block: '.#{$ns}constructor-block';
 
             &_l {
                 margin-top: $indentL;
-                padding-bottom: $indentL;
 
                 &:first-child {
                     margin-top: $indentL;
@@ -71,38 +48,36 @@ $block: '.#{$ns}constructor-block';
 
             &_xl {
                 margin-top: $indentXL;
-                padding-bottom: $indentXL;
 
                 &:first-child {
                     margin-top: $indentXL;
                 }
             }
+        }
 
-            &_xxl {
-                margin-top: $indentXXL;
-                padding-bottom: $indentXXL;
-
-                &:first-child {
-                    margin-top: $indentXXL;
-                }
+        &_indentBottom {
+            &_0 {
+                padding-bottom: 0;
             }
 
-            &_xxxl {
-                margin-top: $indentXXXL;
-                padding-bottom: $indentXXXL;
-
-                &:first-child {
-                    margin-top: $indentXXXL;
-                }
+            &_xs {
+                padding-bottom: $indentXS;
             }
 
-            &_4xl {
-                margin-top: $indent4XL;
-                padding-bottom: $indent4XL;
+            &_s {
+                padding-bottom: $indentSM;
+            }
 
-                &:first-child {
-                    margin-top: $indent4XL;
-                }
+            &_m {
+                padding-bottom: $indentM;
+            }
+
+            &_l {
+                padding-bottom: $indentL;
+            }
+
+            &_xl {
+                padding-bottom: $indentXL;
             }
         }
     }

--- a/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.scss
+++ b/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.scss
@@ -1,0 +1,109 @@
+@import '../../../../../styles/variables';
+@import '../../../../../styles/mixins';
+
+$block: '.#{$ns}constructor-block';
+
+#{$block} {
+    @include add-specificity(&) {
+        &_indent {
+            &_xxxs {
+                margin-top: $indentXXXS;
+                padding-bottom: $indentXXXS;
+
+                &:first-child {
+                    margin-top: $indentXXXS;
+                }
+            }
+
+            &_xxs {
+                margin-top: $indentXXS;
+                padding-bottom: $indentXXS;
+
+                &:first-child {
+                    margin-top: $indentXXS;
+                }
+            }
+
+            &_xs {
+                margin-top: $indentXS;
+                padding-bottom: $indentXS;
+
+                &:first-child {
+                    margin-top: $indentXS;
+                }
+            }
+
+            &_s {
+                margin-top: $indentS;
+                padding-bottom: $indentS;
+
+                &:first-child {
+                    margin-top: $indentS;
+                }
+            }
+
+            &_sm {
+                margin-top: $indentSM;
+                padding-bottom: $indentSM;
+
+                &:first-child {
+                    margin-top: $indentSM;
+                }
+            }
+
+            &_m {
+                margin-top: $indentM;
+                padding-bottom: $indentM;
+
+                &:first-child {
+                    margin-top: $indentM;
+                }
+            }
+
+            &_l {
+                margin-top: $indentL;
+                padding-bottom: $indentL;
+
+                &:first-child {
+                    margin-top: $indentL;
+                }
+            }
+
+            &_xl {
+                margin-top: $indentXL;
+                padding-bottom: $indentXL;
+
+                &:first-child {
+                    margin-top: $indentXL;
+                }
+            }
+
+            &_xxl {
+                margin-top: $indentXXL;
+                padding-bottom: $indentXXL;
+
+                &:first-child {
+                    margin-top: $indentXXL;
+                }
+            }
+
+            &_xxxl {
+                margin-top: $indentXXXL;
+                padding-bottom: $indentXXXL;
+
+                &:first-child {
+                    margin-top: $indentXXXL;
+                }
+            }
+
+            &_4xl {
+                margin-top: $indent4XL;
+                padding-bottom: $indent4XL;
+
+                &:first-child {
+                    margin-top: $indent4XL;
+                }
+            }
+        }
+    }
+}

--- a/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.tsx
+++ b/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.tsx
@@ -11,6 +11,8 @@ import {
 } from '../../../../models';
 import {block} from '../../../../utils';
 
+import './ConstructorBlock.scss';
+
 interface ConstructorBlockProps extends Pick<BlockDecorationProps, 'index'> {
     data: ConstructorBlockType;
 }
@@ -22,7 +24,7 @@ export const ConstructorBlock: React.FC<WithChildren<ConstructorBlockProps>> = (
     data,
     children,
 }) => {
-    const {type} = data;
+    const {type, indent} = data;
     const blockBaseProps = useMemo(
         () => _.pick(data, ['anchor', 'visible', 'resetPaddings']),
         [data],
@@ -30,7 +32,7 @@ export const ConstructorBlock: React.FC<WithChildren<ConstructorBlockProps>> = (
 
     return (
         <BlockDecoration type={type} index={index} {...blockBaseProps}>
-            <BlockBase className={b({type})} {...blockBaseProps}>
+            <BlockBase className={b({type, indent})} {...blockBaseProps}>
                 {children}
             </BlockBase>
         </BlockDecoration>

--- a/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.tsx
+++ b/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.tsx
@@ -24,7 +24,7 @@ export const ConstructorBlock: React.FC<WithChildren<ConstructorBlockProps>> = (
     data,
     children,
 }) => {
-    const {type, indentTop, indentBottom} = data;
+    const {type, indentTop = 'l', indentBottom = 'l'} = data;
     const blockBaseProps = useMemo(
         () => _.pick(data, ['anchor', 'visible', 'resetPaddings']),
         [data],

--- a/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.tsx
+++ b/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.tsx
@@ -24,7 +24,7 @@ export const ConstructorBlock: React.FC<WithChildren<ConstructorBlockProps>> = (
     data,
     children,
 }) => {
-    const {type, indent} = data;
+    const {type, indentTop, indentBottom} = data;
     const blockBaseProps = useMemo(
         () => _.pick(data, ['anchor', 'visible', 'resetPaddings']),
         [data],
@@ -32,7 +32,7 @@ export const ConstructorBlock: React.FC<WithChildren<ConstructorBlockProps>> = (
 
     return (
         <BlockDecoration type={type} index={index} {...blockBaseProps}>
-            <BlockBase className={b({type, indent})} {...blockBaseProps}>
+            <BlockBase className={b({type, indentTop, indentBottom})} {...blockBaseProps}>
                 {children}
             </BlockBase>
         </BlockDecoration>

--- a/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.tsx
+++ b/src/containers/PageConstructor/components/ConstructorBlock/ConstructorBlock.tsx
@@ -24,15 +24,20 @@ export const ConstructorBlock: React.FC<WithChildren<ConstructorBlockProps>> = (
     data,
     children,
 }) => {
-    const {type, indentTop = 'l', indentBottom = 'l'} = data;
+    const {type, indent} = data;
     const blockBaseProps = useMemo(
         () => _.pick(data, ['anchor', 'visible', 'resetPaddings']),
         [data],
     );
 
+    const {top, bottom} = indent || {top: 'l', bottom: 'l'};
+
     return (
         <BlockDecoration type={type} index={index} {...blockBaseProps}>
-            <BlockBase className={b({type, indentTop, indentBottom})} {...blockBaseProps}>
+            <BlockBase
+                className={b({type, indentTop: top, indentBottom: bottom})}
+                {...blockBaseProps}
+            >
                 {children}
             </BlockBase>
         </BlockDecoration>

--- a/src/models/constructor-items/blocks.ts
+++ b/src/models/constructor-items/blocks.ts
@@ -65,6 +65,7 @@ export interface Childable {
 export interface BlockBaseProps {
     anchor?: AnchorProps;
     visible?: GridColumnSize;
+    /** @deprecated */
     resetPaddings?: boolean;
     qa?: string;
 }

--- a/src/models/constructor.ts
+++ b/src/models/constructor.ts
@@ -17,8 +17,10 @@ export interface Menu {
 }
 
 export type ConstructorBlock = (ConstructorItem | CustomBlock) & {
-    indentTop?: string;
-    indentBottom?: string;
+    indent?: {
+        top?: string;
+        bottom?: string;
+    };
 };
 
 export interface PageContent extends Animatable {

--- a/src/models/constructor.ts
+++ b/src/models/constructor.ts
@@ -16,7 +16,10 @@ export interface Menu {
     title: string;
 }
 
-export type ConstructorBlock = (ConstructorItem | CustomBlock) & {indent?: string};
+export type ConstructorBlock = (ConstructorItem | CustomBlock) & {
+    indentTop?: string;
+    indentBottom?: string;
+};
 
 export interface PageContent extends Animatable {
     blocks: ConstructorBlock[];

--- a/src/models/constructor.ts
+++ b/src/models/constructor.ts
@@ -16,7 +16,7 @@ export interface Menu {
     title: string;
 }
 
-export type ConstructorBlock = ConstructorItem | CustomBlock;
+export type ConstructorBlock = (ConstructorItem | CustomBlock) & {indent?: string};
 
 export interface PageContent extends Animatable {
     blocks: ConstructorBlock[];

--- a/src/text-transform/transformers.ts
+++ b/src/text-transform/transformers.ts
@@ -51,7 +51,7 @@ function transformBlock(lang: Lang, blocksConfig: BlocksConfig, block: Construct
                         if (parser) {
                             block[field] = parser(transformer, block[field]);
                         } else if (typeof block[field] === 'string') {
-                            block[field] = transformer(block[field]);
+                            block[field] = transformer(block[field] as string);
                         }
                     }
                 });

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -164,6 +164,7 @@
         padding: 0 0 $indentL;
 
         &:first-child {
+            // @deprecated
             margin-top: var(--pc-first-block-indent, #{$indentXXL});
         }
     }

--- a/styles/storybook/common.scss
+++ b/styles/storybook/common.scss
@@ -30,6 +30,7 @@
 
 .pc-page-constructor {
     --pc-first-block-mobile-indent: 32px;
+    // @deprecated
     --pc-first-block-indent: 64px;
     margin-bottom: 120px;
 }

--- a/styles/storybook/common.scss
+++ b/styles/storybook/common.scss
@@ -29,6 +29,7 @@
 }
 
 .pc-page-constructor {
+    // @deprecated
     --pc-first-block-mobile-indent: 32px;
     // @deprecated
     --pc-first-block-indent: 64px;


### PR DESCRIPTION
- now `resetPadding` are deprecated
- add `indentTop`, and `indentBottom` for al blocks; sizes - `0 - xs - s - m - l - xl`
- add className prop for CardLayoutBlock
- now `--pc-first-block-indent` are deprecated