### PR TITLE
fix: remove unnecessary indents

### DIFF
--- a/src/blocks/Header/Header.scss
+++ b/src/blocks/Header/Header.scss
@@ -76,9 +76,6 @@ $backgroundWidth: 1440px;
 
     &__description {
         margin-top: $indentXS;
-        font-weight: normal;
-        @include text-size(caption-2);
-        margin-block-end: var(--g-text-body-1-line-height);
 
         .yfm,
         .yfm * {
@@ -189,10 +186,8 @@ $backgroundWidth: 1440px;
 
     &__overtitle {
         @include text-size(body-3);
-        margin-block-start: var(--g-text-body-3-line-height);
 
         margin-bottom: $indentXXXS;
-        font-weight: 400;
 
         a {
             @include link();


### PR DESCRIPTION
- There is no need to add `margin-block-start` and `margin-block-end` for this parts. From this PR https://github.com/gravity-ui/page-constructor/pull/416/files
- there in no need to add `font-weight: normal` for div
- there is no need to add `font-size` because it is yfm-component and all styles applied for .yfm *
