### PR TITLE
fix: refactor indents for navigation popup

### DIFF
--- a/src/navigation/components/NavigationItem/NavigationItem.scss
+++ b/src/navigation/components/NavigationItem/NavigationItem.scss
@@ -35,6 +35,10 @@ $block: '.#{$ns}navigation-item';
 
         &_dropdown {
             margin-bottom: 0;
+
+            #{$block}__content_type_link {
+                padding: $indentXXXS $indentXXS;
+            }
         }
     }
 }

--- a/src/navigation/components/NavigationPopup/NavigationPopup.scss
+++ b/src/navigation/components/NavigationPopup/NavigationPopup.scss
@@ -18,7 +18,6 @@ $block: '.#{$ns}navigation-popup';
     &__link {
         height: 36px;
         line-height: 20px;
-        padding: $indentXXXS $indentXXS;
 
         border-radius: 8px;
 


### PR DESCRIPTION
_Dropdown navigation element_

The problem is that now the link is only the text and not the entire list item.
To see difference compare prod storybook and storybook from this branch.