### PR TITLE
fix: make BasicCard icon unshrinkable

### DIFF
--- a/src/components/IconWrapper/IconWrapper.scss
+++ b/src/components/IconWrapper/IconWrapper.scss
@@ -16,6 +16,10 @@ $block: '.#{$ns}icon-wrapper';
         }
     }
 
+    &__icon-container {
+        flex-shrink: 0;
+    }
+
     &__icon {
         max-width: 100%;
         margin-bottom: $indentXXS;

--- a/src/components/IconWrapper/IconWrapper.tsx
+++ b/src/components/IconWrapper/IconWrapper.tsx
@@ -21,7 +21,11 @@ const IconWrapper = (props: PropsWithChildren<IconWrapperProps>) => {
     return (
         <div className={b({['icon-position']: iconPosition})}>
             {iconProps && (
-                <Image {...iconProps} className={b('icon', {['icon-position']: iconPosition})} />
+                <Image
+                    {...iconProps}
+                    containerClassName={b('icon-container')}
+                    className={b('icon', {['icon-position']: iconPosition})}
+                />
             )}
             <div className={b({['content']: iconPosition})}>{children}</div>
         </div>


### PR DESCRIPTION
Removed flex-shrink from BasicCard icon