### PR TITLE
fix: questionblock-link-clickable-all-rowwidth #923

### DIFF
--- a/src/blocks/Questions/QuestionBlockItem/QuestionBlockItem.scss
+++ b/src/blocks/Questions/QuestionBlockItem/QuestionBlockItem.scss
@@ -43,6 +43,7 @@ $block: '.#{$ns}QuestionsBlockItem';
                 border-radius: calc(
                     var(--g-focus-border-radius) + 2px
                 ); // as outline-offset is -2px
+                display: inline-block; //fixes the Link to be clickable in entire row width
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en 

Fixes: Link in Questions block available to clicked in all row width #923 
![image](https://github.com/gravity-ui/page-constructor/assets/64165691/88aa1529-8619-4148-ade9-652f2927cdd8)
