### PR TITLE
fix: video dont starts from beginning on click

### DIFF
--- a/src/components/ReactPlayer/ReactPlayer.tsx
+++ b/src/components/ReactPlayer/ReactPlayer.tsx
@@ -246,6 +246,7 @@ export const ReactPlayerBlock = React.forwardRef<ReactPlayerBlockHandler, ReactP
                 if (
                     isMuted &&
                     playerRef &&
+                    controls === MediaVideoControlsType.Custom &&
                     customControlsType === CustomControlsType.WithMuteButton
                 ) {
                     playerRef.seekTo(0);
@@ -262,7 +263,15 @@ export const ReactPlayerBlock = React.forwardRef<ReactPlayerBlockHandler, ReactP
                 // In order to the progress bar to update (equals 0) before displaying
                 setTimeout(() => setMuted(!isMuted), 0);
             },
-            [playerRef, customControlsType, playEvents, stopEvents, handleAnalytics, setProps],
+            [
+                playerRef,
+                customControlsType,
+                playEvents,
+                stopEvents,
+                handleAnalytics,
+                setProps,
+                controls,
+            ],
         );
 
         const handleClickPreview = useCallback(() => {


### PR DESCRIPTION
For video with default controls player is not working properly.
On any click on control it starts video from beginning because of default props 
`customControlsType = CustomControlsType.WithMuteButton`

This fix changes this behaviour, the video starts from 0 seconds only if developer choose custom controls with mute button type