### PR TITLE
fix: video mute on video click

### DIFF
--- a/src/components/ReactPlayer/ReactPlayer.tsx
+++ b/src/components/ReactPlayer/ReactPlayer.tsx
@@ -343,12 +343,14 @@ export const ReactPlayerBlock = React.forwardRef<ReactPlayerBlockHandler, ReactP
         }, [isPlaying, onPlay, onPause]);
 
         const handleClick = useCallback(() => {
-            if (customControlsType === CustomControlsType.WithMuteButton) {
-                changeMute(muted);
-            } else {
-                onPlayClick();
+            if (controls === MediaVideoControlsType.Custom) {
+                if (customControlsType === CustomControlsType.WithMuteButton) {
+                    changeMute(muted);
+                } else {
+                    onPlayClick();
+                }
             }
-        }, [changeMute, customControlsType, muted, onPlayClick]);
+        }, [changeMute, customControlsType, muted, onPlayClick, controls]);
 
         const onFocusIn = useCallback(() => setHovered(true), []);
         const onFocusOut = useCallback(() => setHovered(false), []);


### PR DESCRIPTION
Video change mute state on any click on player without custom controls, it looks like user clicks on video timeline and then his video is muted, although before that it was with sound