### PR TITLE
feat: add customization to mobile navigation

### DIFF
--- a/src/models/constructor.ts
+++ b/src/models/constructor.ts
@@ -1,5 +1,7 @@
 import React, {PropsWithChildren} from 'react';
 
+import {CustomMobileMenuButtonProps, CustomMobileMenuItemsProps} from '../navigation/models';
+
 import {Animatable, BlockDecorationProps, ConstructorItem, ThemedMediaProps} from './';
 
 export interface PageData {
@@ -41,10 +43,20 @@ export type ShouldRenderBlock = (block: ConstructorBlock, blockKey: string) => B
 export type OnInit = (data: InitConstrucorState) => void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ComponentProps = React.ComponentProps<React.ComponentClass<any>>;
+
 export type CustomItem =
     | React.PropsWithChildren<ComponentProps>
     | React.ComponentType<PropsWithChildren<ComponentProps>>;
 export type CustomItems = Record<string, CustomItem>;
+
+export type CustomMobileMenuButton =
+    | React.PropsWithChildren<CustomMobileMenuButtonProps & ComponentProps>
+    | React.ComponentType<PropsWithChildren<CustomMobileMenuButtonProps & ComponentProps>>;
+export type CustomMobileMenuItem =
+    | React.PropsWithChildren<CustomMobileMenuItemsProps & ComponentProps>
+    | React.ComponentType<PropsWithChildren<CustomMobileMenuItemsProps & ComponentProps>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CustomHookData = Record<string, any>;
 
 export interface LoadableConfigItem {
     fetch: FetchLoadableData;

--- a/src/models/constructor.ts
+++ b/src/models/constructor.ts
@@ -49,10 +49,9 @@ export type CustomItem =
     | React.ComponentType<PropsWithChildren<ComponentProps>>;
 export type CustomItems = Record<string, CustomItem>;
 
-export type CustomMobileMenuButton =
-    | React.PropsWithChildren<CustomMobileMenuButtonProps & ComponentProps>
-    | React.ComponentType<PropsWithChildren<CustomMobileMenuButtonProps & ComponentProps>>;
-export type CustomMobileMenuItem =
+export type CustomMobileMenuButton = React.ComponentType<CustomMobileMenuButtonProps>;
+export type CustomMobileMenuItem = React.ComponentType<CustomMobileMenuItemsProps & ComponentProps>;
+export type CustomMobileHeaderItem =
     | React.PropsWithChildren<CustomMobileMenuItemsProps & ComponentProps>
     | React.ComponentType<PropsWithChildren<CustomMobileMenuItemsProps & ComponentProps>>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/models/navigation.ts
+++ b/src/models/navigation.ts
@@ -1,7 +1,12 @@
 import {CustomMobileMenuAppearanceSide} from '../navigation/models';
 import {ThemeSupporting} from '../utils';
 
-import {CustomHookData, CustomMobileMenuButton, CustomMobileMenuItem} from './constructor';
+import {
+    CustomHookData,
+    CustomMobileHeaderItem,
+    CustomMobileMenuButton,
+    CustomMobileMenuItem,
+} from './constructor';
 import {ButtonProps, ImageProps} from './constructor-items';
 
 export enum NavigationItemType {
@@ -109,7 +114,7 @@ export interface CustomMobileMenuData {
 }
 
 export interface CustomMobileHeaderData {
-    headerMobileItems?: CustomMobileMenuItem[];
+    mobileHeaderItems?: CustomMobileHeaderItem[];
     CustomMobileMenuButton?: CustomMobileMenuButton;
 }
 

--- a/src/models/navigation.ts
+++ b/src/models/navigation.ts
@@ -1,5 +1,7 @@
+import {CustomMobileMenuAppearanceSide} from '../navigation/models';
 import {ThemeSupporting} from '../utils';
 
+import {CustomHookData, CustomMobileMenuButton, CustomMobileMenuItem} from './constructor';
 import {ButtonProps, ImageProps} from './constructor-items';
 
 export enum NavigationItemType {
@@ -93,6 +95,22 @@ export interface HeaderData {
     iconSize?: number;
     withBorder?: boolean;
     withBorderOnScroll?: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useCustomHook?: (...args: any[]) => CustomHookData;
+    customMobileMenuData?: CustomMobileMenuData;
+    customMobileHeaderData?: CustomMobileHeaderData;
+}
+
+export interface CustomMobileMenuData {
+    appearanceSide?: CustomMobileMenuAppearanceSide;
+    Header?: CustomMobileMenuItem;
+    Content?: CustomMobileMenuItem;
+    Footer?: CustomMobileMenuItem;
+}
+
+export interface CustomMobileHeaderData {
+    headerMobileItems?: CustomMobileMenuItem[];
+    CustomMobileMenuButton?: CustomMobileMenuButton;
 }
 
 export interface FooterColumn {

--- a/src/navigation/components/DesktopNavigation/DesktopNavigation.scss
+++ b/src/navigation/components/DesktopNavigation/DesktopNavigation.scss
@@ -17,7 +17,8 @@ $block: '.#{$ns}desktop-navigation';
         z-index: 2;
     }
 
-    &__mobile-menu-button {
+    &__mobile-menu-button,
+    &__custom-mobile-menu-button {
         @include add-specificity(&) {
             @include mobile-tablet-only();
         }
@@ -28,6 +29,17 @@ $block: '.#{$ns}desktop-navigation';
     &__right {
         display: flex;
         align-items: center;
+    }
+
+    &__custom-mobile-navigation {
+        @include add-specificity(&) {
+            position: relative;
+
+            flex: 1 0 0;
+            justify-content: flex-end;
+
+            @include mobile-tablet-only();
+        }
     }
 
     &__navigation {
@@ -42,19 +54,22 @@ $block: '.#{$ns}desktop-navigation';
     }
 
     &__right {
-        flex: 0;
+        flex: 3 0 0;
         justify-content: flex-end;
 
         @include text-size(body-2);
     }
 
-    &__navigation-container {
+    &__navigation-container,
+    &__custom-mobile-navigation-container {
         display: flex;
         overflow-x: hidden;
         flex: 1 0 0;
         justify-content: space-between;
         align-items: center;
+    }
 
+    &__navigation-container {
         margin-right: $indentM;
     }
 
@@ -68,8 +83,9 @@ $block: '.#{$ns}desktop-navigation';
         cursor: pointer;
     }
 
+    &__links,
     &__buttons,
-    &__links {
+    &__mobile-buttons {
         display: flex;
         align-items: center;
 
@@ -83,6 +99,16 @@ $block: '.#{$ns}desktop-navigation';
             &:not(:last-child) {
                 margin-right: $indentXS;
             }
+        }
+    }
+
+    &__mobile-buttons {
+        @include mobile-tablet-only();
+    }
+
+    &__mobile-buttons &__item {
+        &:not(:last-child) {
+            margin-right: 0;
         }
     }
 
@@ -101,8 +127,13 @@ $block: '.#{$ns}desktop-navigation';
     }
 
     @media (max-width: map-get($gridBreakpoints, 'md') - 1) {
-        &__navigation-container {
+        &__navigation-container,
+        &__custom-mobile-navigation-container {
             justify-content: flex-end;
+        }
+
+        &__navigation-container {
+            flex: 0 0 0;
         }
 
         &__left {

--- a/src/navigation/components/DesktopNavigation/DesktopNavigation.scss
+++ b/src/navigation/components/DesktopNavigation/DesktopNavigation.scss
@@ -31,31 +31,39 @@ $block: '.#{$ns}desktop-navigation';
         align-items: center;
     }
 
+    &__navigation,
     &__custom-mobile-navigation {
         @include add-specificity(&) {
             position: relative;
-
             flex: 1 0 0;
-            justify-content: flex-end;
-
-            @include mobile-tablet-only();
         }
     }
 
     &__navigation {
         @include add-specificity(&) {
-            position: relative;
-
-            flex: 1 0 0;
             justify-content: flex-start;
 
             @include desktop-only();
         }
     }
 
+    &__custom-mobile-navigation {
+        @include add-specificity(&) {
+            justify-content: flex-end;
+
+            @include mobile-tablet-only();
+        }
+
+        &-container:has(.#{$ns}overflow-scroller__arrow) & {
+            justify-content: flex-start;
+        }
+    }
+
     &__right {
         flex: 3 0 0;
         justify-content: flex-end;
+
+        max-width: 50%;
 
         @include text-size(body-2);
     }

--- a/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -35,7 +35,10 @@ const DesktopNavigation: React.FC<DesktopNavigationProps> = ({
     );
 
     const mobileMenuButton = CustomMobileMenuButton ? (
-        <div onClick={mobileButtonDefaultClickAction}>
+        <div
+            className={b('custom-mobile-menu-button-wrapper')}
+            onClick={mobileButtonDefaultClickAction}
+        >
             <CustomMobileMenuButton
                 className={b('custom-mobile-menu-button')}
                 isSidebarOpened={isSidebarOpened}

--- a/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -17,46 +17,84 @@ const DesktopNavigation: React.FC<DesktopNavigationProps> = ({
     rightItemsWithIconSize,
     isSidebarOpened,
     onSidebarOpenedChange,
+    customHookData,
+    customMobileHeaderData,
     onActiveItemChange,
     activeItemId,
-}) => (
-    <div className={b('wrapper')}>
-        {logo && (
-            <div className={b('left')}>
-                <Logo {...logo} className={b('logo')} />
-            </div>
-        )}
-        <div className={b('navigation-container')}>
-            <OverflowScroller className={b('navigation')} onScrollStart={onActiveItemChange}>
-                <NavigationList
-                    items={leftItemsWithIconSize}
-                    onActiveItemChange={onActiveItemChange}
-                    className={b('links')}
-                    itemClassName={b('item')}
-                    column={ItemColumnName.Left}
-                    activeItemId={activeItemId}
-                    menuLayout={NavigationLayout.Desktop}
-                />
-            </OverflowScroller>
-        </div>
-        <div className={b('right')}>
-            <MobileMenuButton
-                isSidebarOpened={isSidebarOpened}
-                onSidebarOpenedChange={onSidebarOpenedChange}
-            />
-            {rightItemsWithIconSize && (
-                <NavigationList
-                    onActiveItemChange={onActiveItemChange}
-                    column={ItemColumnName.Right}
-                    items={rightItemsWithIconSize}
-                    activeItemId={activeItemId}
-                    className={b('buttons')}
-                    itemClassName={b('item')}
-                    menuLayout={NavigationLayout.Desktop}
-                />
+}) => {
+    const {headerMobileItems = [], CustomMobileMenuButton = null} = customMobileHeaderData;
+
+    const mobileMenuButton = CustomMobileMenuButton ? (
+        <CustomMobileMenuButton
+            className={b('custom-mobile-menu-button')}
+            isSidebarOpened={isSidebarOpened}
+            onSidebarOpenedChange={onSidebarOpenedChange}
+            customHookData={customHookData}
+        />
+    ) : (
+        <MobileMenuButton
+            isSidebarOpened={isSidebarOpened}
+            onSidebarOpenedChange={onSidebarOpenedChange}
+        />
+    );
+
+    return (
+        <div className={b('wrapper')}>
+            {logo && (
+                <div className={b('left')}>
+                    <Logo {...logo} className={b('logo')} />
+                </div>
             )}
+            <div className={b('navigation-container')}>
+                <OverflowScroller className={b('navigation')} onScrollStart={onActiveItemChange}>
+                    <NavigationList
+                        items={leftItemsWithIconSize}
+                        onActiveItemChange={onActiveItemChange}
+                        className={b('links')}
+                        itemClassName={b('item')}
+                        column={ItemColumnName.Left}
+                        activeItemId={activeItemId}
+                        menuLayout={NavigationLayout.Desktop}
+                    />
+                </OverflowScroller>
+            </div>
+            <div className={b('right')}>
+                {headerMobileItems && (
+                    <div className={b('custom-mobile-navigation-container')}>
+                        <OverflowScroller
+                            className={b('custom-mobile-navigation')}
+                            onScrollStart={onActiveItemChange}
+                            arrowSize={18}
+                        >
+                            <NavigationList
+                                items={headerMobileItems}
+                                onActiveItemChange={onActiveItemChange}
+                                className={b('mobile-buttons')}
+                                itemClassName={b('item')}
+                                column={ItemColumnName.Left}
+                                activeItemId={activeItemId}
+                                menuLayout={NavigationLayout.MobileHorizontal}
+                            />
+                        </OverflowScroller>
+                    </div>
+                )}
+
+                {mobileMenuButton}
+
+                {rightItemsWithIconSize && (
+                    <NavigationList
+                        onActiveItemChange={onActiveItemChange}
+                        column={ItemColumnName.Right}
+                        items={rightItemsWithIconSize}
+                        activeItemId={activeItemId}
+                        className={b('buttons')}
+                        itemClassName={b('item')}
+                        menuLayout={NavigationLayout.Desktop}
+                    />
+                )}
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default DesktopNavigation;

--- a/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -73,7 +73,7 @@ const DesktopNavigation: React.FC<DesktopNavigationProps> = ({
                                 itemClassName={b('item')}
                                 column={ItemColumnName.Left}
                                 activeItemId={activeItemId}
-                                menuLayout={NavigationLayout.MobileHorizontal}
+                                menuLayout={NavigationLayout.MobileHeader}
                             />
                         </OverflowScroller>
                     </div>

--- a/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {MouseEvent, useCallback} from 'react';
 
 import OverflowScroller from '../../../components/OverflowScroller/OverflowScroller';
 import {block} from '../../../utils';
@@ -22,15 +22,26 @@ const DesktopNavigation: React.FC<DesktopNavigationProps> = ({
     onActiveItemChange,
     activeItemId,
 }) => {
-    const {headerMobileItems = [], CustomMobileMenuButton = null} = customMobileHeaderData;
+    const {mobileHeaderItems = [], CustomMobileMenuButton = null} = customMobileHeaderData;
+
+    const mobileButtonDefaultClickAction = useCallback(
+        (event: MouseEvent) => {
+            event.stopPropagation();
+            event.nativeEvent.stopImmediatePropagation();
+
+            onSidebarOpenedChange(!isSidebarOpened);
+        },
+        [isSidebarOpened, onSidebarOpenedChange],
+    );
 
     const mobileMenuButton = CustomMobileMenuButton ? (
-        <CustomMobileMenuButton
-            className={b('custom-mobile-menu-button')}
-            isSidebarOpened={isSidebarOpened}
-            onSidebarOpenedChange={onSidebarOpenedChange}
-            customHookData={customHookData}
-        />
+        <div onClick={mobileButtonDefaultClickAction}>
+            <CustomMobileMenuButton
+                className={b('custom-mobile-menu-button')}
+                isSidebarOpened={isSidebarOpened}
+                customHookData={customHookData}
+            />
+        </div>
     ) : (
         <MobileMenuButton
             isSidebarOpened={isSidebarOpened}
@@ -59,7 +70,7 @@ const DesktopNavigation: React.FC<DesktopNavigationProps> = ({
                 </OverflowScroller>
             </div>
             <div className={b('right')}>
-                {headerMobileItems && (
+                {mobileHeaderItems && (
                     <div className={b('custom-mobile-navigation-container')}>
                         <OverflowScroller
                             className={b('custom-mobile-navigation')}
@@ -67,7 +78,7 @@ const DesktopNavigation: React.FC<DesktopNavigationProps> = ({
                             arrowSize={18}
                         >
                             <NavigationList
-                                items={headerMobileItems}
+                                items={mobileHeaderItems}
                                 onActiveItemChange={onActiveItemChange}
                                 className={b('mobile-buttons')}
                                 itemClassName={b('item')}

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
@@ -12,7 +12,7 @@ $block: '.#{$ns}fullscreen-mobile-navigation';
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: calc(100vh - var(--header-height) + 1px);
+    height: calc(100vh - var(--header-height) + 1);
 
     background-color: var(--g-color-base-background);
     box-shadow: 0 3px 10px var(--g-color-sfx-shadow);

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
@@ -12,7 +12,7 @@ $block: '.#{$ns}fullscreen-mobile-navigation';
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: calc(100vh - var(--header-height));
+    height: calc(100vh - var(--header-height) + 1px);
 
     background-color: var(--g-color-base-background);
     box-shadow: 0 3px 10px var(--g-color-sfx-shadow);

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
@@ -12,7 +12,7 @@ $block: '.#{$ns}fullscreen-mobile-navigation';
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: calc(100vh - var(--header-height) + 1);
+    height: calc(100vh - var(--header-height) + 1px);
 
     background-color: var(--g-color-base-background);
     box-shadow: 0 3px 10px var(--g-color-sfx-shadow);

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
@@ -35,8 +35,8 @@ $block: '.#{$ns}fullscreen-mobile-navigation';
     &__content {
         flex: 1 0 0;
 
-        padding-top: $indentSM;
-        padding-bottom: $indentSM;
+        padding-top: $indentXXS;
+        padding-bottom: $indentXXS;
 
         overflow-y: auto;
 
@@ -55,8 +55,8 @@ $block: '.#{$ns}fullscreen-mobile-navigation';
 
     @media (max-width: map-get($gridBreakpoints, 'md') - 1) {
         &__nav-lists {
-            padding-left: $indentSM;
-            padding-right: $indentSM;
+            padding-left: $indentXS;
+            padding-right: $indentXS;
         }
     }
 
@@ -72,7 +72,6 @@ $block: '.#{$ns}fullscreen-mobile-navigation';
 
         padding-bottom: $indentSM;
         @include reset-list-style();
-        margin-bottom: $indentSM;
     }
 
     &__rows:last-child {

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.scss
@@ -1,0 +1,122 @@
+@import '../../../../styles/variables';
+@import '../../../../styles/mixins';
+
+$block: '.#{$ns}fullscreen-mobile-navigation';
+
+#{$block} {
+    position: fixed;
+    top: var(--header-height);
+    left: 0;
+    z-index: 100;
+
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: calc(100vh - var(--header-height));
+
+    background-color: var(--g-color-base-background);
+    box-shadow: 0 3px 10px var(--g-color-sfx-shadow);
+
+    transition-timing-function: linear;
+    transition-property: left, right, top, bottom;
+    transition-duration: 300ms;
+
+    @include text-size(body-2);
+    @include mobile-tablet-only();
+
+    &__header,
+    &__content,
+    &__footer {
+        position: relative;
+        height: fit-content;
+        width: 100%;
+    }
+
+    &__content {
+        flex: 1 0 0;
+
+        padding-top: $indentSM;
+        padding-bottom: $indentSM;
+
+        overflow-y: auto;
+
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+
+        &::-webkit-scrollbar {
+            display: none;
+        }
+
+        &_has-custom-content {
+            padding-top: 0;
+            padding-bottom: 0;
+        }
+    }
+
+    @media (max-width: map-get($gridBreakpoints, 'md') - 1) {
+        &__nav-lists {
+            padding-left: $indentSM;
+            padding-right: $indentSM;
+        }
+    }
+
+    &__button {
+        margin-top: $indentSM;
+    }
+
+    &__rows {
+        position: relative;
+
+        display: flex;
+        flex-direction: column;
+
+        padding-bottom: $indentSM;
+        @include reset-list-style();
+        margin-bottom: $indentSM;
+    }
+
+    &__rows:last-child {
+        margin-bottom: 0;
+    }
+
+    &__dropdown-item {
+        &:not(:last-child) {
+            margin-bottom: $indentXS;
+        }
+    }
+
+    &__popup {
+        @include mobile-tablet-only();
+        @include navigation-popup();
+    }
+
+    // * disable page scroll
+    body:has(&_opened) {
+        overflow-y: hidden;
+    }
+
+    // * appear directions
+    &_left {
+        left: -105vw;
+    }
+    &_right {
+        left: 200vw;
+    }
+    &_top {
+        top: -105vh;
+    }
+    &_bottom {
+        top: 200vh;
+    }
+
+    &_opened {
+        &#{$block}_left,
+        &#{$block}_right {
+            left: 0;
+        }
+        &#{$block}_top,
+        &#{$block}_bottom {
+            top: calc(0px + var(--header-height));
+        }
+    }
+}

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.tsx
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.tsx
@@ -59,7 +59,9 @@ const FullscreenMobileNavigation: React.FC<CustomMobileMenuProps> = memo(
             <Portal>
                 <div className={b({opened: isOpened, [appearanceSide]: true})}>
                     <div className={b('header')}>{header}</div>
-                    <div className={b('content', {'has-custom-content': Content})}>{content}</div>
+                    <div className={b('content', {'has-custom-content': Boolean(Content)})}>
+                        {content}
+                    </div>
                     <div className={b('footer')}>{footer}</div>
                 </div>
             </Portal>

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.tsx
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import {Portal} from '@gravity-ui/uikit';
+
+import {useMount} from '../../../hooks';
+import {block} from '../../../utils';
+import {CustomMobileMenuProps, ItemColumnName, NavigationLayout} from '../../models';
+import {NavigationList} from '../NavigationList/NavigationList';
+
+import './FullscreenMobileNavigation.scss';
+
+const b = block('fullscreen-mobile-navigation');
+
+const FullscreenMobileNavigation: React.FC<CustomMobileMenuProps> = ({
+    isOpened,
+    topItems,
+    bottomItems,
+    customHookData,
+    customMobileMenuData,
+    ...props
+}) => {
+    const {
+        appearanceSide = 'right',
+        Header = null,
+        Content = null,
+        Footer = null,
+    } = customMobileMenuData;
+
+    const [isMounted, setIsMounted] = React.useState(false);
+
+    useMount(() => setIsMounted(true));
+
+    if (!isMounted) {
+        return null;
+    }
+
+    const header = Header ? <Header customHookData={customHookData} /> : null;
+    const footer = Footer ? <Footer customHookData={customHookData} /> : null;
+    const content = Content ? (
+        <Content customHookData={customHookData} />
+    ) : (
+        <div className={b('nav-lists')}>
+            {topItems && (
+                <NavigationList
+                    className={b('rows')}
+                    items={topItems}
+                    column={ItemColumnName.Top}
+                    menuLayout={NavigationLayout.Mobile}
+                    {...props}
+                />
+            )}
+            {bottomItems && (
+                <NavigationList
+                    className={b('rows')}
+                    items={bottomItems}
+                    column={ItemColumnName.Bottom}
+                    menuLayout={NavigationLayout.Mobile}
+                    {...props}
+                />
+            )}
+        </div>
+    );
+
+    return (
+        <Portal>
+            <div className={b({opened: isOpened, [appearanceSide]: true})}>
+                <div className={b('header')}>{header}</div>
+                <div className={b('content', {'has-custom-content': Content})}>{content}</div>
+                <div className={b('footer')}>{footer}</div>
+            </div>
+        </Portal>
+    );
+};
+
+export default FullscreenMobileNavigation;

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.tsx
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {memo} from 'react';
 
 import {Portal} from '@gravity-ui/uikit';
 
@@ -11,65 +11,62 @@ import './FullscreenMobileNavigation.scss';
 
 const b = block('fullscreen-mobile-navigation');
 
-const FullscreenMobileNavigation: React.FC<CustomMobileMenuProps> = ({
-    isOpened,
-    topItems,
-    bottomItems,
-    customHookData,
-    customMobileMenuData,
-    ...props
-}) => {
-    const {
-        appearanceSide = 'right',
-        Header = null,
-        Content = null,
-        Footer = null,
-    } = customMobileMenuData;
+const FullscreenMobileNavigation: React.FC<CustomMobileMenuProps> = memo(
+    ({isOpened, topItems, bottomItems, customHookData, customMobileMenuData, ...props}) => {
+        const {
+            appearanceSide = 'right',
+            Header = null,
+            Content = null,
+            Footer = null,
+        } = customMobileMenuData;
 
-    const [isMounted, setIsMounted] = React.useState(false);
+        const [isMounted, setIsMounted] = React.useState(false);
 
-    useMount(() => setIsMounted(true));
+        useMount(() => setIsMounted(true));
 
-    if (!isMounted) {
-        return null;
-    }
+        if (!isMounted) {
+            return null;
+        }
 
-    const header = Header ? <Header customHookData={customHookData} /> : null;
-    const footer = Footer ? <Footer customHookData={customHookData} /> : null;
-    const content = Content ? (
-        <Content customHookData={customHookData} />
-    ) : (
-        <div className={b('nav-lists')}>
-            {topItems && (
-                <NavigationList
-                    className={b('rows')}
-                    items={topItems}
-                    column={ItemColumnName.Top}
-                    menuLayout={NavigationLayout.Mobile}
-                    {...props}
-                />
-            )}
-            {bottomItems && (
-                <NavigationList
-                    className={b('rows')}
-                    items={bottomItems}
-                    column={ItemColumnName.Bottom}
-                    menuLayout={NavigationLayout.Mobile}
-                    {...props}
-                />
-            )}
-        </div>
-    );
-
-    return (
-        <Portal>
-            <div className={b({opened: isOpened, [appearanceSide]: true})}>
-                <div className={b('header')}>{header}</div>
-                <div className={b('content', {'has-custom-content': Content})}>{content}</div>
-                <div className={b('footer')}>{footer}</div>
+        const header = Header ? <Header customHookData={customHookData} /> : null;
+        const footer = Footer ? <Footer customHookData={customHookData} /> : null;
+        const content = Content ? (
+            <Content customHookData={customHookData} />
+        ) : (
+            <div className={b('nav-lists')}>
+                {topItems && (
+                    <NavigationList
+                        className={b('rows')}
+                        items={topItems}
+                        column={ItemColumnName.Top}
+                        menuLayout={NavigationLayout.Mobile}
+                        {...props}
+                    />
+                )}
+                {bottomItems && (
+                    <NavigationList
+                        className={b('rows')}
+                        items={bottomItems}
+                        column={ItemColumnName.Bottom}
+                        menuLayout={NavigationLayout.Mobile}
+                        {...props}
+                    />
+                )}
             </div>
-        </Portal>
-    );
-};
+        );
+
+        return (
+            <Portal>
+                <div className={b({opened: isOpened, [appearanceSide]: true})}>
+                    <div className={b('header')}>{header}</div>
+                    <div className={b('content', {'has-custom-content': Content})}>{content}</div>
+                    <div className={b('footer')}>{footer}</div>
+                </div>
+            </Portal>
+        );
+    },
+);
+
+FullscreenMobileNavigation.displayName = 'FullscreenMobileNavigation';
 
 export default FullscreenMobileNavigation;

--- a/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.tsx
+++ b/src/navigation/components/FullscreenMobileNavigation/FullscreenMobileNavigation.tsx
@@ -39,7 +39,7 @@ const FullscreenMobileNavigation: React.FC<CustomMobileMenuProps> = memo(
                         className={b('rows')}
                         items={topItems}
                         column={ItemColumnName.Top}
-                        menuLayout={NavigationLayout.Mobile}
+                        menuLayout={NavigationLayout.MobileFullscreen}
                         {...props}
                     />
                 )}
@@ -48,7 +48,7 @@ const FullscreenMobileNavigation: React.FC<CustomMobileMenuProps> = memo(
                         className={b('rows')}
                         items={bottomItems}
                         column={ItemColumnName.Bottom}
-                        menuLayout={NavigationLayout.Mobile}
+                        menuLayout={NavigationLayout.MobileFullscreen}
                         {...props}
                     />
                 )}

--- a/src/navigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/src/navigation/components/MobileNavigation/MobileNavigation.tsx
@@ -35,7 +35,7 @@ const MobileNavigation: React.FC<MobileNavigationProps> = ({
                             className={b('rows')}
                             items={topItems}
                             column={ItemColumnName.Top}
-                            menuLayout={NavigationLayout.Mobile}
+                            menuLayout={NavigationLayout.MobileBasic}
                             {...props}
                         />
                     )}
@@ -44,7 +44,7 @@ const MobileNavigation: React.FC<MobileNavigationProps> = ({
                             className={b('rows')}
                             items={bottomItems}
                             column={ItemColumnName.Bottom}
-                            menuLayout={NavigationLayout.Mobile}
+                            menuLayout={NavigationLayout.MobileBasic}
                             {...props}
                         />
                     )}

--- a/src/navigation/components/Navigation/Navigation.tsx
+++ b/src/navigation/components/Navigation/Navigation.tsx
@@ -27,14 +27,12 @@ export const Navigation: React.FC<NavigationProps> = ({data, logo, className}) =
         iconSize = 20,
         withBorder = false,
         withBorderOnScroll = true,
-        useCustomHook = () => {
-            return {};
-        },
+        useCustomHook = () => {},
         customMobileMenuData,
         customMobileHeaderData = {},
     } = data;
 
-    const customHookData = useCustomHook();
+    const customHookData = useCustomHook() || {};
 
     const [isSidebarOpened, setIsSidebarOpened] = useState(false);
     const [activeItemId, setActiveItemId] = useState<string | undefined>(undefined);

--- a/src/navigation/components/Navigation/Navigation.tsx
+++ b/src/navigation/components/Navigation/Navigation.tsx
@@ -8,6 +8,7 @@ import {ClassNameProps, HeaderData, ThemedNavigationLogoData} from '../../../mod
 import {block} from '../../../utils';
 import {getNavigationItemWithIconSize} from '../../utils';
 import DesktopNavigation from '../DesktopNavigation/DesktopNavigation';
+import FullscreenMobileNavigation from '../FullscreenMobileNavigation/FullscreenMobileNavigation';
 import MobileNavigation from '../MobileNavigation/MobileNavigation';
 
 import './Navigation.scss';
@@ -26,7 +27,15 @@ export const Navigation: React.FC<NavigationProps> = ({data, logo, className}) =
         iconSize = 20,
         withBorder = false,
         withBorderOnScroll = true,
+        useCustomHook = () => {
+            return {};
+        },
+        customMobileMenuData,
+        customMobileHeaderData = {},
     } = data;
+
+    const customHookData = useCustomHook();
+
     const [isSidebarOpened, setIsSidebarOpened] = useState(false);
     const [activeItemId, setActiveItemId] = useState<string | undefined>(undefined);
     const [showBorder, setShowBorder] = useState(withBorder);
@@ -63,29 +72,49 @@ export const Navigation: React.FC<NavigationProps> = ({data, logo, className}) =
         return () => window.removeEventListener('scroll', scrollHandler);
     });
 
+    const desktopNavigation = (
+        <DesktopNavigation
+            logo={logo}
+            activeItemId={activeItemId}
+            onActiveItemChange={onActiveItemChange}
+            leftItemsWithIconSize={leftItemsWithIconSize}
+            rightItemsWithIconSize={rightItemsWithIconSize}
+            isSidebarOpened={isSidebarOpened}
+            onSidebarOpenedChange={onSidebarOpenedChange}
+            customHookData={customHookData}
+            customMobileHeaderData={customMobileHeaderData}
+        />
+    );
+
+    const mobileNavigation = customMobileMenuData ? (
+        <FullscreenMobileNavigation
+            isOpened={isSidebarOpened}
+            topItems={leftItemsWithIconSize}
+            bottomItems={rightItemsWithIconSize}
+            customHookData={customHookData}
+            customMobileMenuData={customMobileMenuData}
+            activeItemId={activeItemId}
+            onActiveItemChange={onActiveItemChange}
+        />
+    ) : (
+        <OutsideClick onOutsideClick={() => onSidebarOpenedChange(false)}>
+            <MobileNavigation
+                topItems={leftItemsWithIconSize}
+                bottomItems={rightItemsWithIconSize}
+                isOpened={isSidebarOpened}
+                activeItemId={activeItemId}
+                onActiveItemChange={onActiveItemChange}
+            />
+        </OutsideClick>
+    );
+
     return (
         <Grid className={b({'with-border': showBorder}, className)}>
             <Row>
                 <Col>
                     <nav>
-                        <DesktopNavigation
-                            logo={logo}
-                            activeItemId={activeItemId}
-                            onActiveItemChange={onActiveItemChange}
-                            leftItemsWithIconSize={leftItemsWithIconSize}
-                            rightItemsWithIconSize={rightItemsWithIconSize}
-                            isSidebarOpened={isSidebarOpened}
-                            onSidebarOpenedChange={onSidebarOpenedChange}
-                        />
-                        <OutsideClick onOutsideClick={() => onSidebarOpenedChange(false)}>
-                            <MobileNavigation
-                                topItems={leftItemsWithIconSize}
-                                bottomItems={rightItemsWithIconSize}
-                                isOpened={isSidebarOpened}
-                                activeItemId={activeItemId}
-                                onActiveItemChange={onActiveItemChange}
-                            />
-                        </OutsideClick>
+                        {desktopNavigation}
+                        {mobileNavigation}
                     </nav>
                 </Col>
             </Row>

--- a/src/navigation/components/NavigationItem/NavigationItem.scss
+++ b/src/navigation/components/NavigationItem/NavigationItem.scss
@@ -41,9 +41,6 @@ $block: '.#{$ns}navigation-item';
             padding: $indentXXS $indentXXS $indentXXS $indentSM;
 
             margin-bottom: 0;
-
-            font-weight: var(--g-text-accent-font-weight);
-            @include text-size(body-3);
         }
 
         &_dropdown {

--- a/src/navigation/components/NavigationItem/NavigationItem.scss
+++ b/src/navigation/components/NavigationItem/NavigationItem.scss
@@ -33,8 +33,17 @@ $block: '.#{$ns}navigation-item';
             margin-bottom: $indentSM;
         }
 
-        &_mobile-horizontal {
+        &_mobile-header {
             margin-bottom: 0;
+        }
+
+        &_mobile-fullscreen {
+            padding: $indentXXS $indentXXS $indentXXS $indentSM;
+
+            margin-bottom: 0;
+
+            font-weight: var(--g-text-accent-font-weight);
+            @include text-size(body-3);
         }
 
         &_dropdown {

--- a/src/navigation/components/NavigationItem/NavigationItem.scss
+++ b/src/navigation/components/NavigationItem/NavigationItem.scss
@@ -33,6 +33,10 @@ $block: '.#{$ns}navigation-item';
             margin-bottom: $indentSM;
         }
 
+        &_mobile-horizontal {
+            margin-bottom: 0;
+        }
+
         &_dropdown {
             margin-bottom: 0;
 

--- a/src/navigation/models.ts
+++ b/src/navigation/models.ts
@@ -25,8 +25,9 @@ export enum ItemColumnName {
 
 export enum NavigationLayout {
     Desktop = 'desktop',
-    Mobile = 'mobile',
-    MobileHorizontal = 'mobile-horizontal',
+    MobileBasic = 'mobile',
+    MobileHeader = 'mobile-header',
+    MobileFullscreen = 'mobile-fullscreen',
     Dropdown = 'dropdown',
 }
 

--- a/src/navigation/models.ts
+++ b/src/navigation/models.ts
@@ -2,6 +2,9 @@ import {MouseEventHandler} from 'react';
 
 import {
     ClassNameProps,
+    CustomHookData,
+    CustomMobileHeaderData,
+    CustomMobileMenuData,
     NavigationItemData,
     NavigationItemModel,
     NavigationLinkItem,
@@ -23,7 +26,15 @@ export enum ItemColumnName {
 export enum NavigationLayout {
     Desktop = 'desktop',
     Mobile = 'mobile',
+    MobileHorizontal = 'mobile-horizontal',
     Dropdown = 'dropdown',
+}
+
+export enum CustomMobileMenuAppearanceSide {
+    right = 'right',
+    left = 'left',
+    bottom = 'bottom',
+    top = 'top',
 }
 
 export interface ActiveItemProps {
@@ -66,12 +77,32 @@ export interface DesktopNavigationProps extends MobileMenuButtonProps, ActiveIte
     logo: ThemedNavigationLogoData;
     leftItemsWithIconSize: NavigationItemModel[];
     rightItemsWithIconSize?: NavigationItemModel[];
+    customHookData: CustomHookData;
+    customMobileHeaderData: CustomMobileHeaderData;
 }
 
 export interface MobileNavigationProps extends ClassNameProps, ActiveItemProps {
     isOpened?: boolean;
     topItems?: NavigationItemModel[];
     bottomItems?: NavigationItemModel[];
+}
+
+export interface CustomMobileMenuProps extends ClassNameProps, ActiveItemProps {
+    isOpened?: boolean;
+    topItems?: NavigationItemModel[];
+    bottomItems?: NavigationItemModel[];
+    customHookData: CustomHookData;
+    customMobileMenuData: CustomMobileMenuData;
+}
+
+export interface CustomMobileMenuButtonProps extends ClassNameProps {
+    isSidebarOpened: boolean;
+    onSidebarOpenedChange: (isSidebarOpened: boolean) => void;
+    customHookData?: CustomHookData;
+}
+
+export interface CustomMobileMenuItemsProps {
+    customHookData?: CustomHookData;
 }
 
 export interface NavigationProps extends MobileMenuButtonProps, ActiveItemProps {

--- a/src/navigation/models.ts
+++ b/src/navigation/models.ts
@@ -16,6 +16,11 @@ export interface MobileMenuButtonProps {
     onSidebarOpenedChange: (arg: boolean) => void;
 }
 
+export interface CustomMobileMenuButtonProps extends ClassNameProps {
+    isSidebarOpened: boolean;
+    customHookData?: CustomHookData;
+}
+
 export enum ItemColumnName {
     Left = 'left',
     Right = 'right',
@@ -94,12 +99,6 @@ export interface CustomMobileMenuProps extends ClassNameProps, ActiveItemProps {
     bottomItems?: NavigationItemModel[];
     customHookData: CustomHookData;
     customMobileMenuData: CustomMobileMenuData;
-}
-
-export interface CustomMobileMenuButtonProps extends ClassNameProps {
-    isSidebarOpened: boolean;
-    onSidebarOpenedChange: (isSidebarOpened: boolean) => void;
-    customHookData?: CustomHookData;
 }
 
 export interface CustomMobileMenuItemsProps {


### PR DESCRIPTION
# Add customization to mobile navigation

## Summary

Several features have been added that together allow you to make a custom mobile menu, add elements to the header, and link your custom components with your own logic using states, etc.

## Feat 1. Custom header items on mobile 
Added the ability to insert items into the mobile header using NavigationList and OverflowScroller.

### Preview

**IPhone XR**
<img width="353" alt="feat 1 on IPhone XR 1" src="https://github.com/user-attachments/assets/d8c4e142-18bd-497d-add6-f12001ba0b59">
<img width="355" alt="feat 1 on IPhone XR 2" src="https://github.com/user-attachments/assets/dc22bfc0-dc31-4e9b-b6f2-b05d6d11a670">
<img width="355" alt="feat 1 on IPhone XR 3" src="https://github.com/user-attachments/assets/fed20e7f-9ce0-4604-bcf0-0c527be4c50d">

https://github.com/user-attachments/assets/539e65fb-f7cd-496f-89c7-cdbe66960ee1

**IPad Mini**
<img width="561" alt="feat 1 on IPad Mini" src="https://github.com/user-attachments/assets/e2214c26-2231-4390-b725-bc10bfbaa173">

### How to add 

```
const mobileHeaderItems = [{type: 'item1'}, {type: 'item2'}, {type: 'item3'}];

<PageConstructor
    custom={{
        navigation: {
            item3: () => ...,
        },
    }
    ...
    navigation={
         header: {
    ...
                 // new
                 customMobileHeaderData: {
                         mobileHeaderItems,
                  },
    ...
             }
        }
/>
```

## Feat 2. CustomMobileMenuButton
Added the ability to use a custom mobile menu button.

<img width="352" alt="demo of custom mobile menu button" src="https://github.com/user-attachments/assets/5e9f7fa5-599a-44d8-bbba-c9586e94f02b">

### How to add 

```
const MobileMenuButton = () => <SomeComponent />

<PageConstructor
    ...
    navigation={
         header: {
    ...
                 // new
                 customMobileHeaderData: {
                         CustomMobileMenuButton: MobileMenuButton,
                  },
    ...
             }
        }
/>
```

## Feat 3. CustomMobileMenu

Added the ability to use a full-screen mobile menu, with custom Header, Content and Footer components, which are optional. It is also possible to choose the direction of the menu appearance.

**FullscreenMobileNavigation with Header (1), Content (2) and Footer (3)**
<img width="219" alt="Снимок экрана 2024-08-12 в 12 43 39" src="https://github.com/user-attachments/assets/714bc0cc-bbb1-448c-be8d-cf42bb2b4835">

Without CustomContent (use basic content)
<img width="220" alt="Снимок экрана 2024-08-12 в 12 44 57" src="https://github.com/user-attachments/assets/2eb4a48f-fae0-4c8d-8f9a-50b22b4e2225">

### How to add 

```
const MobileMenuButton = () => <SomeComponent />

<PageConstructor
    ...
    navigation={
         header: {
    ...
                 // new
                 customMobileMenuData: {
                         appearanceSide: 'left', 
                         Header: SomeHeaderComponent',
                         Content: SomeContentComponent',
                         Footer: SomeFooterComponent,
                  },
    ...
             }
        }
/>
```

## Feat 4

Added the ability to transfer a custom hook to navigation. The result of executing this hook is transmitted strictly to custom components (from this PR), and does not affect anything else.

This feature allows you to create interaction between components (for example, the Header from the mobile menu and CustomMobileMenuButton), which will occur at the level of the Navigation component. This will add more interactivity to the menu on mobile devices.


### How to add 

```
const MobileMenuButton = () => <SomeComponent />

<PageConstructor
    ...
    navigation={
         header: {
    ...
                 // new
                 useCustomHook: useSomeCustomHook,
    ...
             }
        }
/>
```