### PR TITLE
fix(Content): apply control-position: bottom to links

### DIFF
--- a/src/sub-blocks/Content/Content.scss
+++ b/src/sub-blocks/Content/Content.scss
@@ -200,7 +200,7 @@ $darkSecondary: var(--g-color-text-dark-secondary);
             #{$block}__text,
             #{$block}__title {
                 &:has(+ #{$block}__buttons),
-                &:has(+ #{$block}__link) {
+                &:has(+ #{$block}__links) {
                     margin-bottom: auto;
                 }
             }


### PR DESCRIPTION
classname being wrong prevented the proper alignment of links in Content
`controlPosition: bottom` doesn't work for them

I can see that in the same file there are other instances of `#{$block}__link`. This classname doesn't exist in the component, so they do nothing, and either cause bugs, or should be removed entirely. Depending on the intention. I don't know how it should be, so only fixed the one I understand.