### PR TITLE
fix: dynamic imports in vite prod build

### DIFF
--- a/src/editor/components/AddBlock/AddBlock.tsx
+++ b/src/editor/components/AddBlock/AddBlock.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 // TODO fix in https://github.com/gravity-ui/page-constructor/issues/965
 
-import React, {PropsWithChildren, useMemo, useRef, useState} from 'react';
+import React, {PropsWithChildren, useEffect, useMemo, useRef, useState} from 'react';
 
 import {Plus} from '@gravity-ui/icons';
 import {Popup, TextInput} from '@gravity-ui/uikit';
@@ -10,7 +10,7 @@ import {Popup, TextInput} from '@gravity-ui/uikit';
 import {blockMap} from '../../../constructor-items';
 import {Block, BlockType, ClassNameProps} from '../../../models';
 import {block} from '../../../utils';
-import EditorBlocksData from '../../data';
+import {EditorBlocksData, getEditorBlocksData} from '../../data';
 
 import './AddBlock.scss';
 
@@ -25,16 +25,29 @@ const sortedBlockNames = Object.keys(blockMap).sort();
 const AddBlock = ({onAdd, className}: PropsWithChildren<AddBlockProps>) => {
     const [isOpened, setIsOpened] = useState(false);
     const [search, setSearch] = useState('');
+    const [editorBlocksData, setEditorBlocksData] = useState<EditorBlocksData | null>(null);
+
     const ref = useRef(null);
-    const blocks = useMemo(
-        () =>
-            sortedBlockNames.filter((blockName) =>
-                EditorBlocksData[blockName as BlockType].meta.title
-                    .toLocaleLowerCase()
-                    .startsWith(search.toLocaleLowerCase()),
-            ),
-        [search],
-    );
+    const blocks = useMemo(() => {
+        if (!editorBlocksData) {
+            return [];
+        }
+
+        return sortedBlockNames.filter((blockName) =>
+            editorBlocksData[blockName as BlockType]?.meta.title
+                .toLocaleLowerCase()
+                .startsWith(search.toLocaleLowerCase()),
+        );
+    }, [editorBlocksData, search]);
+
+    useEffect(() => {
+        const loadEditorBlocksData = async () => {
+            const data = await getEditorBlocksData();
+            setEditorBlocksData(data);
+        };
+
+        loadEditorBlocksData();
+    }, []);
 
     return (
         <div className={b(null, className)} ref={ref}>
@@ -68,10 +81,14 @@ const AddBlock = ({onAdd, className}: PropsWithChildren<AddBlockProps>) => {
                     </div>
                     <div className={b('blocks')}>
                         {blocks.map((blockName) => {
-                            const blockData = EditorBlocksData[blockName as BlockType];
-                            const Preview = blockData?.preview as React.FC<
-                                React.SVGProps<SVGSVGElement>
-                            >;
+                            const blockData = editorBlocksData?.[blockName as BlockType];
+
+                            if (!blockData) {
+                                return null;
+                            }
+
+                            const Preview: React.FC<React.SVGProps<SVGSVGElement>> =
+                                blockData.preview;
 
                             return (
                                 <div


### PR DESCRIPTION
Чиним проблему динамических импортов на vite
Что vite вообще отказывается нормально полифилить require и их динамические импорты с json 
В этом пр-е заменил require на import, json остались в отдельных чанках и идут через динамику, в cjs, остались require
Preview все никак не хотят заводится через динамику, поэтому пришлось запихнуть их в бандл, а так возможно можно потыкаться с lazy loading 