### PR TITLE
fix fetchPriority in ImageBase.tsx

### DIFF
--- a/src/components/ImageBase/ImageBase.tsx
+++ b/src/components/ImageBase/ImageBase.tsx
@@ -22,7 +22,7 @@ export const ImageBase = ({fetchPriority, ...props}: ImageBaseProps) => {
         // this prop is good to have to improve Core Web Vitals.
         // So, here is a workaround to assign the attr.
         // eslint-disable-next-line jsx-a11y/alt-text
-        <img {...{fetchpriority: fetchPriority}} {...props} />
+        <img {...{fetchPriority: fetchPriority}} {...props} />
     );
 };
 


### PR DESCRIPTION
React 19 produces error about wrong case for fetchPriority attribute for img tag(see below). This change will fix this.

```
Warning: Invalid DOM property `fetchpriority`. Did you mean `fetchPriority`?
    at img
    at ImageBase (webpack-internal:///(ssr)/./node_modules/@gravity-ui/page-constructor/build/esm/components/ImageBase/ImageBase.js:14:11)
    at picture
    at Image (webpack-internal:///(ssr)/./node_modules/@gravity-ui/page-constructor/build/esm/components/Image/Image.js:25:78)
```