### PR TITLE
fix: slider a11y (#982)

### DIFF
--- a/src/components/MediaBase/MediaBase.tsx
+++ b/src/components/MediaBase/MediaBase.tsx
@@ -68,7 +68,7 @@ export const MediaBase = (props: MediaBaseProps) => {
                     </Col>
                     {card ? (
                         <Col sizes={mediaSizes}>
-                            <div>{card}</div>
+                            <div className={b('card')}>{card}</div>
                         </Col>
                     ) : null}
                 </Row>


### PR DESCRIPTION
Seems like the animation was removed unintentionally in the:
https://github.com/gravity-ui/page-constructor/pull/722/files#diff-eab7b8bc7750406fcf0f69868100dc9eea8c27389864de2815968e8b229af324L72-R71
