### PR TITLE
Fix: fix import from node_modules 

### DIFF
--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -1,4 +1,4 @@
-@import '../node_modules/@gravity-ui/uikit/styles/mixins.scss';
+@import '~@gravity-ui/uikit/styles/mixins.scss';
 @import './variables.scss';
 
 //common

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -1,4 +1,4 @@
-@import '~@gravity-ui/uikit/styles/mixins.scss';
+@import '@gravity-ui/uikit/styles/mixins.scss';
 @import './variables.scss';
 
 //common

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -1,4 +1,4 @@
-@import 'node_modules/@gravity-ui/uikit/styles/mixins.scss';
+@import '../node_modules/@gravity-ui/uikit/styles/mixins.scss';
 @import './variables.scss';
 
 //common


### PR DESCRIPTION
When using `sass-loader@16` I got this error

```
Can't find stylesheet to import.  
@import 'node_modules/@gravity-ui/uikit/styles/mixins.scss';
node_modules/@gravity-ui/page-constructor/styles/mixins.scss 1:9                
```
So this is a small patch