### PR TITLE
refactor: Props with children fix (After removing React.FC)

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -277,7 +277,7 @@ type FetchLoadableData<TData = any> = (blockKey: string) => Promise<TData>;
 ```jsx
 import {Grid, Row, Col} from '@gravity-ui/page-constructor';
 
-const Page: React.FC<PageProps> = ({children}) => (
+const Page = ({children}: React.PropsWithChildren<PageProps>) => (
   <Grid>
     <Row>
       <Col sizes={{lg: 4, sm: 6, all: 12}}>{children}</Col>
@@ -293,7 +293,7 @@ const Page: React.FC<PageProps> = ({children}) => (
 ```jsx
 import {Navigation} from '@gravity-ui/page-constructor';
 
-const Page: React.FC<PageProps> = ({data, logo}) => <Navigation data={data} logo={logo} />;
+const Page = ({data, logo}: React.PropsWithChildren<PageProps>) => <Navigation data={data} logo={logo} />;
 ```
 
 ### Блоки

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Usage example:
 ```jsx
 import {Grid, Row, Col} from '@gravity-ui/page-constructor';
 
-const Page: React.FC<PageProps> = ({children}) => (
+const Page = ({children}: PropsWithChildren<PageProps>) => (
   <Grid>
     <Row>
       <Col sizes={{lg: 4, sm: 6, all: 12}}>{children}</Col>
@@ -294,7 +294,7 @@ Page navigation can also be used separately from the constructor:
 ```jsx
 import {Navigation} from '@gravity-ui/page-constructor';
 
-const Page: React.FC<PageProps> = ({data, logo}) => <Navigation data={data} logo={logo} />;
+const Page= ({data, logo}: React.PropsWithChildren<PageProps>) => <Navigation data={data} logo={logo} />;
 ```
 
 ### Blocks

--- a/src/blocks/CardLayout/CardLayout.tsx
+++ b/src/blocks/CardLayout/CardLayout.tsx
@@ -21,7 +21,7 @@ export type CardLayoutBlockProps = React.PropsWithChildren<
 
 const b = block('card-layout-block');
 
-const CardLayout: React.FC<CardLayoutBlockProps> = ({
+const CardLayout = ({
     title,
     description,
     animated,
@@ -30,7 +30,7 @@ const CardLayout: React.FC<CardLayoutBlockProps> = ({
     className,
     titleClassName,
     background,
-}) => {
+}: CardLayoutBlockProps) => {
     const theme = useTheme();
     const {border, ...backgroundImageProps} = getThemedValue(background || {}, theme);
     return (

--- a/src/blocks/FilterBlock/FilterBlock.tsx
+++ b/src/blocks/FilterBlock/FilterBlock.tsx
@@ -23,7 +23,7 @@ const FilterBlock = ({
     colSizes,
     centered,
     animated,
-}: React.PropsWithChildren<FilterBlockProps>) => {
+}: FilterBlockProps) => {
     const tabButtons = React.useMemo(() => {
         const allButton: ButtonTabsItemProps | undefined = allTag
             ? {id: null, title: typeof allTag === 'boolean' ? i18n('label-all-tag') : allTag}

--- a/src/blocks/FilterBlock/FilterBlock.tsx
+++ b/src/blocks/FilterBlock/FilterBlock.tsx
@@ -13,7 +13,7 @@ import './FilterBlock.scss';
 
 const b = block('filter-block');
 
-const FilterBlock: React.FC<FilterBlockProps> = ({
+const FilterBlock = ({
     title,
     description,
     tags,
@@ -23,7 +23,7 @@ const FilterBlock: React.FC<FilterBlockProps> = ({
     colSizes,
     centered,
     animated,
-}) => {
+}: React.PropsWithChildren<FilterBlockProps>) => {
     const tabButtons = React.useMemo(() => {
         const allButton: ButtonTabsItemProps | undefined = allTag
             ? {id: null, title: typeof allTag === 'boolean' ? i18n('label-all-tag') : allTag}

--- a/src/blocks/Form/Form.tsx
+++ b/src/blocks/Form/Form.tsx
@@ -21,7 +21,7 @@ const b = block('form-block');
 
 const colSizes = {[GridColumnSize.Lg]: 6, [GridColumnSize.All]: 12};
 
-const FormBlock: React.FC<FormBlockProps> = (props) => {
+const FormBlock = (props: React.PropsWithChildren<FormBlockProps>) => {
     const {formData, title, textContent, direction = FormBlockDirection.Center, background} = props;
     const [contentLoaded, setContentLoaded] = React.useState(false);
     const isMobile = React.useContext(MobileContext);

--- a/src/blocks/Form/Form.tsx
+++ b/src/blocks/Form/Form.tsx
@@ -21,7 +21,7 @@ const b = block('form-block');
 
 const colSizes = {[GridColumnSize.Lg]: 6, [GridColumnSize.All]: 12};
 
-const FormBlock = (props: React.PropsWithChildren<FormBlockProps>) => {
+const FormBlock = (props: FormBlockProps) => {
     const {formData, title, textContent, direction = FormBlockDirection.Center, background} = props;
     const [contentLoaded, setContentLoaded] = React.useState(false);
     const isMobile = React.useContext(MobileContext);

--- a/src/blocks/Share/Share.tsx
+++ b/src/blocks/Share/Share.tsx
@@ -17,9 +17,7 @@ import {i18n} from './i18n';
 import './Share.scss';
 
 interface IconsProps {
-    [key: string]: (
-        props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>,
-    ) => React.ReactNode;
+    [key: string]: (props: React.SVGProps<SVGSVGElement>) => React.ReactNode;
 }
 
 const icons: IconsProps = {

--- a/src/blocks/Share/Share.tsx
+++ b/src/blocks/Share/Share.tsx
@@ -17,7 +17,9 @@ import {i18n} from './i18n';
 import './Share.scss';
 
 interface IconsProps {
-    [key: string]: React.FC<React.SVGProps<SVGSVGElement>>;
+    [key: string]: (
+        props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>,
+    ) => React.ReactNode;
 }
 
 const icons: IconsProps = {

--- a/src/components/ButtonTabs/ButtonTabs.tsx
+++ b/src/components/ButtonTabs/ButtonTabs.tsx
@@ -29,7 +29,7 @@ export interface ButtonTabsProps extends QAProps {
     getTabContentElementId?: (tabId: string) => string;
 }
 
-const ButtonTabs: React.FC<ButtonTabsProps> = ({
+const ButtonTabs = ({
     className,
     items,
     activeTab,
@@ -38,7 +38,7 @@ const ButtonTabs: React.FC<ButtonTabsProps> = ({
     qa,
     getTabElementId,
     getTabContentElementId,
-}) => {
+}: React.PropsWithChildren<ButtonTabsProps>) => {
     const activeTabId: string | null = React.useMemo(() => {
         if (activeTab) {
             return activeTab;

--- a/src/components/ButtonTabs/ButtonTabs.tsx
+++ b/src/components/ButtonTabs/ButtonTabs.tsx
@@ -38,7 +38,7 @@ const ButtonTabs = ({
     qa,
     getTabElementId,
     getTabContentElementId,
-}: React.PropsWithChildren<ButtonTabsProps>) => {
+}: ButtonTabsProps) => {
     const activeTabId: string | null = React.useMemo(() => {
         if (activeTab) {
             return activeTab;

--- a/src/components/Buttons/Buttons.tsx
+++ b/src/components/Buttons/Buttons.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {ButtonProps, ContentSize} from '../../models';
 import {block} from '../../utils';
 import Button from '../Button/Button';
@@ -27,14 +25,7 @@ function getButtonSize(size: ContentSize) {
     }
 }
 
-const Buttons = ({
-    className,
-    titleId,
-    buttons,
-    size = 's',
-    qa,
-    buttonQa,
-}: React.PropsWithChildren<ButtonsProps>) =>
+const Buttons = ({className, titleId, buttons, size = 's', qa, buttonQa}: ButtonsProps) =>
     buttons ? (
         <div className={b({size}, className)} data-qa={qa}>
             {buttons.map((item) => (

--- a/src/components/Buttons/Buttons.tsx
+++ b/src/components/Buttons/Buttons.tsx
@@ -27,14 +27,14 @@ function getButtonSize(size: ContentSize) {
     }
 }
 
-const Buttons: React.FC<ButtonsProps> = ({
+const Buttons = ({
     className,
     titleId,
     buttons,
     size = 's',
     qa,
     buttonQa,
-}) =>
+}: React.PropsWithChildren<ButtonsProps>) =>
     buttons ? (
         <div className={b({size}, className)} data-qa={qa}>
             {buttons.map((item) => (

--- a/src/components/CardBase/CardBase.tsx
+++ b/src/components/CardBase/CardBase.tsx
@@ -39,9 +39,9 @@ export interface CardFooterBaseProps {
 
 const b = block('card-base-block');
 
-const Header: React.FC<React.PropsWithChildren<CardHeaderBaseProps>> = () => null;
-const Content: React.FC<React.PropsWithChildren<{}>> = () => null;
-const Footer: React.FC<React.PropsWithChildren<CardFooterBaseProps>> = () => null;
+const Header: (props: React.PropsWithChildren<CardHeaderBaseProps>) => React.ReactNode = () => null;
+const Content: (props: React.PropsWithChildren<{}>) => React.ReactNode = () => null;
+const Footer: (props: React.PropsWithChildren<CardFooterBaseProps>) => React.ReactNode = () => null;
 
 export const Layout = (props: CardBasePropsType) => {
     const {

--- a/src/components/InnerForm/InnerForm.tsx
+++ b/src/components/InnerForm/InnerForm.tsx
@@ -17,7 +17,7 @@ interface InnerFormProps {
     className?: string;
 }
 
-const InnerForm: React.FC<InnerFormProps> = (props) => {
+const InnerForm = (props: React.PropsWithChildren<InnerFormProps>) => {
     const {formData, onContentLoad, className} = props;
     const formsConfig = React.useContext(FormsContext);
     const theme = useTheme();

--- a/src/components/InnerForm/InnerForm.tsx
+++ b/src/components/InnerForm/InnerForm.tsx
@@ -17,7 +17,7 @@ interface InnerFormProps {
     className?: string;
 }
 
-const InnerForm = (props: React.PropsWithChildren<InnerFormProps>) => {
+const InnerForm = (props: InnerFormProps) => {
     const {formData, onContentLoad, className} = props;
     const formsConfig = React.useContext(FormsContext);
     const theme = useTheme();

--- a/src/components/Links/Links.tsx
+++ b/src/components/Links/Links.tsx
@@ -27,7 +27,14 @@ type LinksProps = {
     linkQa?: string;
 };
 
-const Links: React.FC<LinksProps> = ({className, titleId, links, size = 's', qa, linkQa}) =>
+const Links = ({
+    className,
+    titleId,
+    links,
+    size = 's',
+    qa,
+    linkQa,
+}: React.PropsWithChildren<LinksProps>) =>
     links ? (
         <div className={b({size}, className)} data-qa={qa}>
             {links?.map((link) => (

--- a/src/components/Map/GoogleMap.tsx
+++ b/src/components/Map/GoogleMap.tsx
@@ -29,7 +29,7 @@ function getScriptSrc(params: GoogleMapLinkParams) {
     )}`;
 }
 
-const GoogleMap: React.FC<GMapProps> = (props) => {
+const GoogleMap = (props: React.PropsWithChildren<GMapProps>) => {
     const {address, zoom, className} = props;
     const {apiKey, scriptSrc} = React.useContext(MapsContext);
     const {lang = Lang.Ru} = React.useContext(LocaleContext);

--- a/src/components/Map/GoogleMap.tsx
+++ b/src/components/Map/GoogleMap.tsx
@@ -29,7 +29,7 @@ function getScriptSrc(params: GoogleMapLinkParams) {
     )}`;
 }
 
-const GoogleMap = (props: React.PropsWithChildren<GMapProps>) => {
+const GoogleMap = (props: GMapProps) => {
     const {address, zoom, className} = props;
     const {apiKey, scriptSrc} = React.useContext(MapsContext);
     const {lang = Lang.Ru} = React.useContext(LocaleContext);

--- a/src/components/Map/YMap/YandexMap.tsx
+++ b/src/components/Map/YMap/YandexMap.tsx
@@ -23,7 +23,7 @@ const DEFAULT_ZOOM = 9;
 // The real center of the map will be calculated later, using the coordinates of the markers
 const INITIAL_CENTER = [0, 0];
 
-const YandexMap = (props: React.PropsWithChildren<YMapProps>) => {
+const YandexMap = (props: YMapProps) => {
     const {markers, zoom, id, className} = props;
     const {apiKey, scriptSrc, nonce} = React.useContext(MapsContext);
     const isMobile = React.useContext(MobileContext);

--- a/src/components/Map/YMap/YandexMap.tsx
+++ b/src/components/Map/YMap/YandexMap.tsx
@@ -23,7 +23,7 @@ const DEFAULT_ZOOM = 9;
 // The real center of the map will be calculated later, using the coordinates of the markers
 const INITIAL_CENTER = [0, 0];
 
-const YandexMap: React.FC<YMapProps> = (props) => {
+const YandexMap = (props: React.PropsWithChildren<YMapProps>) => {
     const {markers, zoom, id, className} = props;
     const {apiKey, scriptSrc, nonce} = React.useContext(MapsContext);
     const isMobile = React.useContext(MobileContext);

--- a/src/components/Media/FullscreenVideo/FullscreenVideo.tsx
+++ b/src/components/Media/FullscreenVideo/FullscreenVideo.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import FullscreenMedia from '../../FullscreenMedia/FullscreenMedia';
 import Video, {VideoAllProps} from '../Video/Video';
 
-const FullscreenVideo: React.FC<VideoAllProps> = (props) => {
+const FullscreenVideo = (props: React.PropsWithChildren<VideoAllProps>) => {
     return (
         <FullscreenMedia>{(classNames) => <Video {...props} {...classNames} />}</FullscreenMedia>
     );

--- a/src/components/Media/FullscreenVideo/FullscreenVideo.tsx
+++ b/src/components/Media/FullscreenVideo/FullscreenVideo.tsx
@@ -1,9 +1,7 @@
-import * as React from 'react';
-
 import FullscreenMedia from '../../FullscreenMedia/FullscreenMedia';
 import Video, {VideoAllProps} from '../Video/Video';
 
-const FullscreenVideo = (props: React.PropsWithChildren<VideoAllProps>) => {
+const FullscreenVideo = (props: VideoAllProps) => {
     return (
         <FullscreenMedia>{(classNames) => <Video {...props} {...classNames} />}</FullscreenMedia>
     );

--- a/src/components/MediaBase/MediaBase.tsx
+++ b/src/components/MediaBase/MediaBase.tsx
@@ -12,7 +12,7 @@ import './MediaBase.scss';
 
 const b = block('media-base');
 
-const Card: React.FC<React.PropsWithChildren<{}>> = () => null;
+const Card: (props: React.PropsWithChildren<{}>) => React.ReactNode = () => null;
 
 interface MediaBaseProps extends MediaBaseBlockProps {
     children: React.ReactElement;

--- a/src/containers/PageConstructor/components/ConstructorBlocks/ConstructorBlocks.tsx
+++ b/src/containers/PageConstructor/components/ConstructorBlocks/ConstructorBlocks.tsx
@@ -19,7 +19,7 @@ export interface ConstructorBlocksProps {
     items: ConstructorBlockType[];
 }
 
-export const ConstructorBlocks: React.FC<ConstructorBlocksProps> = ({items}) => {
+export const ConstructorBlocks = ({items}: React.PropsWithChildren<ConstructorBlocksProps>) => {
     const {blockTypes, loadables, itemMap, shouldRenderBlock} = React.useContext(InnerContext);
 
     const renderer = (

--- a/src/containers/PageConstructor/components/ConstructorBlocks/ConstructorBlocks.tsx
+++ b/src/containers/PageConstructor/components/ConstructorBlocks/ConstructorBlocks.tsx
@@ -19,7 +19,7 @@ export interface ConstructorBlocksProps {
     items: ConstructorBlockType[];
 }
 
-export const ConstructorBlocks = ({items}: React.PropsWithChildren<ConstructorBlocksProps>) => {
+export const ConstructorBlocks = ({items}: ConstructorBlocksProps) => {
     const {blockTypes, loadables, itemMap, shouldRenderBlock} = React.useContext(InnerContext);
 
     const renderer = (

--- a/src/context/locationContext/locationContext.ts
+++ b/src/context/locationContext/locationContext.ts
@@ -16,7 +16,7 @@ export interface History {
 
 export type RouterLink =
     | React.ComponentClass<RouterLinkProps>
-    | ((props: React.PropsWithChildren<RouterLinkProps>) => React.ReactNode);
+    | ((props: RouterLinkProps) => React.ReactNode);
 
 export type LocationContextProps = {
     history?: History;

--- a/src/context/locationContext/locationContext.ts
+++ b/src/context/locationContext/locationContext.ts
@@ -16,7 +16,7 @@ export interface History {
 
 export type RouterLink =
     | React.ComponentClass<RouterLinkProps>
-    | React.FC<React.PropsWithChildren<RouterLinkProps>>;
+    | ((props: React.PropsWithChildren<RouterLinkProps>) => React.ReactNode);
 
 export type LocationContextProps = {
     history?: History;

--- a/src/context/mapsContext/mapsProvider.tsx
+++ b/src/context/mapsContext/mapsProvider.tsx
@@ -10,7 +10,7 @@ interface MapProviderProps {
 
 export const gmapApiKeyIdInLS = 'gmap-api-key';
 
-export const MapProvider: React.FC<React.PropsWithChildren<MapProviderProps>> = ({
+export const MapProvider: (props: React.PropsWithChildren<MapProviderProps>) => React.ReactNode = ({
     type = MapType.Yandex,
     scriptSrc,
     apiKey,

--- a/src/editor/components/AddBlock/AddBlock.tsx
+++ b/src/editor/components/AddBlock/AddBlock.tsx
@@ -83,8 +83,9 @@ const AddBlock = ({onAdd, className}: React.PropsWithChildren<AddBlockProps>) =>
                                 return null;
                             }
 
-                            const Preview: React.FC<React.SVGProps<SVGSVGElement>> =
-                                blockData.preview;
+                            const Preview: (
+                                props: React.SVGProps<SVGSVGElement>,
+                            ) => React.ReactNode = blockData.preview;
 
                             return (
                                 <button

--- a/src/editor/components/AddBlock/AddBlock.tsx
+++ b/src/editor/components/AddBlock/AddBlock.tsx
@@ -18,7 +18,7 @@ export interface AddBlockProps extends ClassNameProps {
 
 const sortedBlockNames = Object.keys(blockMap).sort();
 
-const AddBlock = ({onAdd, className}: React.PropsWithChildren<AddBlockProps>) => {
+const AddBlock = ({onAdd, className}: AddBlockProps) => {
     const [isOpened, setIsOpened] = React.useState(false);
     const [search, setSearch] = React.useState('');
     const [editorBlocksData, setEditorBlocksData] = React.useState<EditorBlocksData | null>(null);

--- a/src/editor/components/Layout/Layout.tsx
+++ b/src/editor/components/Layout/Layout.tsx
@@ -8,8 +8,8 @@ import './Layout.scss';
 
 const b = block('editor-layout');
 
-const Left: React.FC<React.PropsWithChildren> = () => null;
-const Right: React.FC<React.PropsWithChildren> = () => null;
+const Left: (props: React.PropsWithChildren) => React.ReactNode = () => null;
+const Right: (props: React.PropsWithChildren) => React.ReactNode = () => null;
 
 export interface LayoutProps {
     editMode: EditModeItem;

--- a/src/editor/data/previews/default-preview.tsx
+++ b/src/editor/data/previews/default-preview.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../../../utils/svg';
 
-const DefaultPreview = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+const DefaultPreview = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         width="150"
         height="76"

--- a/src/editor/data/previews/default-preview.tsx
+++ b/src/editor/data/previews/default-preview.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../../../utils/svg';
 
-const DefaultPreview: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const DefaultPreview = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         width="150"
         height="76"

--- a/src/editor/data/previews/header-block.tsx
+++ b/src/editor/data/previews/header-block.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../../../utils/svg';
 
-const Header: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const Header = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         width="150"
         height="76"

--- a/src/editor/data/previews/header-block.tsx
+++ b/src/editor/data/previews/header-block.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../../../utils/svg';
 
-const Header = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+const Header = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         width="150"
         height="76"

--- a/src/editor/dynamic-forms-custom/components/OneOfCustom/OneOfCustom.tsx
+++ b/src/editor/dynamic-forms-custom/components/OneOfCustom/OneOfCustom.tsx
@@ -56,9 +56,10 @@ const getControllerDefautValue = (value: FieldValue, valueSpecType?: SpecTypes) 
  * original component: {propertyName: {option1: {value: propertyValue}}}
  *
  * @param {ObjectIndependentInputProps} props - props of original OneOf component
- * @returns {React.FC<ObjectIndependentInputProps>}
+ * @returns {React.ReactNode}
  */
-export const OneOfCustom: React.FC<ObjectIndependentInputProps> = (props) => {
+
+export const OneOfCustom = (props: React.PropsWithChildren<ObjectIndependentInputProps>) => {
     const {spec, input, name} = props;
     const {properties} = spec;
 

--- a/src/editor/dynamic-forms-custom/components/OneOfCustom/OneOfCustom.tsx
+++ b/src/editor/dynamic-forms-custom/components/OneOfCustom/OneOfCustom.tsx
@@ -59,7 +59,7 @@ const getControllerDefautValue = (value: FieldValue, valueSpecType?: SpecTypes) 
  * @returns {React.ReactNode}
  */
 
-export const OneOfCustom = (props: React.PropsWithChildren<ObjectIndependentInputProps>) => {
+export const OneOfCustom = (props: ObjectIndependentInputProps) => {
     const {spec, input, name} = props;
     const {properties} = spec;
 

--- a/src/editor/icons/Tablet.tsx
+++ b/src/editor/icons/Tablet.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../../utils/svg';
 
-export const Tablet: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const Tablet = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="12"

--- a/src/editor/icons/Tablet.tsx
+++ b/src/editor/icons/Tablet.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../../utils/svg';
 
-export const Tablet = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const Tablet = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="12"

--- a/src/icons/BrandIconDark.tsx
+++ b/src/icons/BrandIconDark.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const BrandIconDark: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const BrandIconDark = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"

--- a/src/icons/BrandIconDark.tsx
+++ b/src/icons/BrandIconDark.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const BrandIconDark = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const BrandIconDark = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"

--- a/src/icons/BrandIconLight.tsx
+++ b/src/icons/BrandIconLight.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const BrandIconLight = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const BrandIconLight = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"

--- a/src/icons/BrandIconLight.tsx
+++ b/src/icons/BrandIconLight.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const BrandIconLight: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const BrandIconLight = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"

--- a/src/icons/BrandName.tsx
+++ b/src/icons/BrandName.tsx
@@ -4,7 +4,7 @@ import {a11yHiddenSvgProps} from '../utils/svg';
 
 export const BRAND_NAME_RATIO = 72 / 16;
 
-export const BrandName = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const BrandName = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="72"

--- a/src/icons/BrandName.tsx
+++ b/src/icons/BrandName.tsx
@@ -4,7 +4,7 @@ import {a11yHiddenSvgProps} from '../utils/svg';
 
 export const BRAND_NAME_RATIO = 72 / 16;
 
-export const BrandName: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const BrandName = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="72"

--- a/src/icons/Chevron.tsx
+++ b/src/icons/Chevron.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Chevron: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const Chevron = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"

--- a/src/icons/Chevron.tsx
+++ b/src/icons/Chevron.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Chevron = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const Chevron = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"

--- a/src/icons/Facebook.tsx
+++ b/src/icons/Facebook.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Facebook = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const Facebook = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/Facebook.tsx
+++ b/src/icons/Facebook.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Facebook: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const Facebook = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/Github.tsx
+++ b/src/icons/Github.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Github: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const Github = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 32 32"

--- a/src/icons/Github.tsx
+++ b/src/icons/Github.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Github = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const Github = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 32 32"

--- a/src/icons/Linkedin.tsx
+++ b/src/icons/Linkedin.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Linkedin: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const Linkedin = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/Linkedin.tsx
+++ b/src/icons/Linkedin.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Linkedin = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const Linkedin = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/NavigationArrow.tsx
+++ b/src/icons/NavigationArrow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const NavigationArrow = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const NavigationArrow = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="9"

--- a/src/icons/NavigationArrow.tsx
+++ b/src/icons/NavigationArrow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const NavigationArrow: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const NavigationArrow = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="9"

--- a/src/icons/NavigationChevron.tsx
+++ b/src/icons/NavigationChevron.tsx
@@ -2,9 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const NavigationChevron = (
-    props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>,
-) => (
+export const NavigationChevron = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="12"

--- a/src/icons/NavigationChevron.tsx
+++ b/src/icons/NavigationChevron.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const NavigationChevron: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const NavigationChevron = (
+    props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>,
+) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="12"

--- a/src/icons/Telegram.tsx
+++ b/src/icons/Telegram.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Telegram = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const Telegram = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/Telegram.tsx
+++ b/src/icons/Telegram.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Telegram: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const Telegram = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/Twitter.tsx
+++ b/src/icons/Twitter.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Twitter: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const Twitter = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/Twitter.tsx
+++ b/src/icons/Twitter.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Twitter = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const Twitter = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/Vk.tsx
+++ b/src/icons/Vk.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Vk: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+export const Vk = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/icons/Vk.tsx
+++ b/src/icons/Vk.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {a11yHiddenSvgProps} from '../utils/svg';
 
-export const Vk = (props: React.PropsWithChildren<React.SVGProps<SVGSVGElement>>) => (
+export const Vk = (props: React.SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/src/models/constructor-items/blocks.ts
+++ b/src/models/constructor-items/blocks.ts
@@ -400,7 +400,7 @@ export interface ContentLayoutBlockProps extends ContentLayoutBlockParams {
     fileContent?: FileLinkProps[];
 }
 
-export type SVGIcon = React.FC<React.SVGProps<SVGSVGElement>>;
+export type SVGIcon = (props: React.SVGProps<SVGSVGElement>) => React.ReactNode;
 
 export interface ContentItemProps {
     title?: string;

--- a/src/navigation/__stories__/CustomButton/CustomButton.tsx
+++ b/src/navigation/__stories__/CustomButton/CustomButton.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {TriangleUp} from '@gravity-ui/icons';
 import {Button} from '@gravity-ui/uikit';
 
@@ -12,7 +10,7 @@ const b = cn('custom-button');
 
 type DCDropdownNavigationItemProps = Pick<NavigationItemProps, 'onClick' | 'isActive'>;
 
-export const CustomButton = (props: React.PropsWithChildren<DCDropdownNavigationItemProps>) => {
+export const CustomButton = (props: DCDropdownNavigationItemProps) => {
     const {onClick, isActive} = props;
 
     return (

--- a/src/navigation/__stories__/CustomButton/CustomButton.tsx
+++ b/src/navigation/__stories__/CustomButton/CustomButton.tsx
@@ -12,7 +12,7 @@ const b = cn('custom-button');
 
 type DCDropdownNavigationItemProps = Pick<NavigationItemProps, 'onClick' | 'isActive'>;
 
-export const CustomButton: React.FC<DCDropdownNavigationItemProps> = (props) => {
+export const CustomButton = (props: React.PropsWithChildren<DCDropdownNavigationItemProps>) => {
     const {onClick, isActive} = props;
 
     return (

--- a/src/navigation/__stories__/CustomComponent/CustomComponent.tsx
+++ b/src/navigation/__stories__/CustomComponent/CustomComponent.tsx
@@ -14,7 +14,7 @@ type DCDropdownNavigationItemProps = Pick<
     'onClick' | 'isActive' | 'menuLayout'
 >;
 
-export const CustomComponent: React.FC<DCDropdownNavigationItemProps> = (props) => {
+export const CustomComponent = (props: React.PropsWithChildren<DCDropdownNavigationItemProps>) => {
     const {onClick, isActive, menuLayout} = props;
 
     const {onKeyDown} = useActionHandlers(onClick);

--- a/src/navigation/__stories__/CustomComponent/CustomComponent.tsx
+++ b/src/navigation/__stories__/CustomComponent/CustomComponent.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {useActionHandlers} from '@gravity-ui/uikit';
 
 import {cn} from '../../../utils';
@@ -14,7 +12,7 @@ type DCDropdownNavigationItemProps = Pick<
     'onClick' | 'isActive' | 'menuLayout'
 >;
 
-export const CustomComponent = (props: React.PropsWithChildren<DCDropdownNavigationItemProps>) => {
+export const CustomComponent = (props: DCDropdownNavigationItemProps) => {
     const {onClick, isActive, menuLayout} = props;
 
     const {onKeyDown} = useActionHandlers(onClick);

--- a/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -11,7 +11,7 @@ import './DesktopNavigation.scss';
 
 const b = block('desktop-navigation');
 
-export const DesktopNavigation: React.FC<DesktopNavigationProps> = ({
+export const DesktopNavigation = ({
     logo,
     leftItemsWithIconSize,
     rightItemsWithIconSize,
@@ -20,7 +20,7 @@ export const DesktopNavigation: React.FC<DesktopNavigationProps> = ({
     onSidebarOpenedChange,
     onActiveItemChange,
     activeItemId,
-}) => (
+}: React.PropsWithChildren<DesktopNavigationProps>) => (
     <div className={b('wrapper')}>
         {logo && (
             <div className={b('left')}>

--- a/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/src/navigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import OverflowScroller from '../../../components/OverflowScroller/OverflowScroller';
 import {block} from '../../../utils';
 import {DesktopNavigationProps, ItemColumnName, NavigationLayout} from '../../models';
@@ -20,7 +18,7 @@ export const DesktopNavigation = ({
     onSidebarOpenedChange,
     onActiveItemChange,
     activeItemId,
-}: React.PropsWithChildren<DesktopNavigationProps>) => (
+}: DesktopNavigationProps) => (
     <div className={b('wrapper')}>
         {logo && (
             <div className={b('left')}>

--- a/src/navigation/components/Logo/Logo.tsx
+++ b/src/navigation/components/Logo/Logo.tsx
@@ -19,7 +19,10 @@ export type LogoProps = ThemedNavigationLogoData & {
     alt?: string;
 };
 
-export const Logo: React.FC<LogoProps> = ({alt = i18n('image-alt'), ...restProps}) => {
+export const Logo = ({
+    alt = i18n('image-alt'),
+    ...restProps
+}: React.PropsWithChildren<LogoProps>) => {
     const props: LogoProps = {...restProps, alt};
     const {hostname, Link} = React.useContext(LocationContext);
     const theme = useTheme();

--- a/src/navigation/components/Logo/Logo.tsx
+++ b/src/navigation/components/Logo/Logo.tsx
@@ -19,10 +19,7 @@ export type LogoProps = ThemedNavigationLogoData & {
     alt?: string;
 };
 
-export const Logo = ({
-    alt = i18n('image-alt'),
-    ...restProps
-}: React.PropsWithChildren<LogoProps>) => {
+export const Logo = ({alt = i18n('image-alt'), ...restProps}: LogoProps) => {
     const props: LogoProps = {...restProps, alt};
     const {hostname, Link} = React.useContext(LocationContext);
     const theme = useTheme();

--- a/src/navigation/components/MobileMenuButton/MobileMenuButton.tsx
+++ b/src/navigation/components/MobileMenuButton/MobileMenuButton.tsx
@@ -12,10 +12,10 @@ const b = block('mobile-menu-button');
 
 const ICON_SIZE = 24;
 
-export const MobileMenuButton: React.FC<MobileMenuButtonProps> = ({
+export const MobileMenuButton = ({
     isSidebarOpened,
     onSidebarOpenedChange,
-}) => (
+}: React.PropsWithChildren<MobileMenuButtonProps>) => (
     <Control
         className={b()}
         onClick={(e: React.MouseEvent) => {

--- a/src/navigation/components/MobileMenuButton/MobileMenuButton.tsx
+++ b/src/navigation/components/MobileMenuButton/MobileMenuButton.tsx
@@ -15,7 +15,7 @@ const ICON_SIZE = 24;
 export const MobileMenuButton = ({
     isSidebarOpened,
     onSidebarOpenedChange,
-}: React.PropsWithChildren<MobileMenuButtonProps>) => (
+}: MobileMenuButtonProps) => (
     <Control
         className={b()}
         onClick={(e: React.MouseEvent) => {

--- a/src/navigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/src/navigation/components/MobileNavigation/MobileNavigation.tsx
@@ -12,13 +12,13 @@ import './MobileNavigation.scss';
 
 const b = block('mobile-navigation');
 
-export const MobileNavigation: React.FC<MobileNavigationProps> = ({
+export const MobileNavigation = ({
     isOpened,
     topItems,
     bottomItems,
     portalContainer,
     ...props
-}) => {
+}: React.PropsWithChildren<MobileNavigationProps>) => {
     const [isMounted, setIsMounted] = React.useState(false);
 
     useMount(() => setIsMounted(true));

--- a/src/navigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/src/navigation/components/MobileNavigation/MobileNavigation.tsx
@@ -18,7 +18,7 @@ export const MobileNavigation = ({
     bottomItems,
     portalContainer,
     ...props
-}: React.PropsWithChildren<MobileNavigationProps>) => {
+}: MobileNavigationProps) => {
     const [isMounted, setIsMounted] = React.useState(false);
 
     useMount(() => setIsMounted(true));

--- a/src/navigation/components/Navigation/Navigation.tsx
+++ b/src/navigation/components/Navigation/Navigation.tsx
@@ -23,7 +23,7 @@ export const Navigation = ({
     logo,
     className,
     mobilePortalContainer,
-}: React.PropsWithChildren<NavigationComponentProps>) => {
+}: NavigationComponentProps) => {
     const {
         leftItems,
         rightItems,

--- a/src/navigation/components/Navigation/Navigation.tsx
+++ b/src/navigation/components/Navigation/Navigation.tsx
@@ -18,12 +18,12 @@ export interface NavigationComponentProps extends ClassNameProps {
     mobilePortalContainer?: React.RefObject<HTMLElement>;
 }
 
-export const Navigation: React.FC<NavigationComponentProps> = ({
+export const Navigation = ({
     data,
     logo,
     className,
     mobilePortalContainer,
-}) => {
+}: React.PropsWithChildren<NavigationComponentProps>) => {
     const {
         leftItems,
         rightItems,

--- a/src/navigation/components/NavigationItem/NavigationItem.tsx
+++ b/src/navigation/components/NavigationItem/NavigationItem.tsx
@@ -19,12 +19,12 @@ const nonComplexNavigationItemTypes = NavigationItemTypes.filter(
     (type) => type !== NavigationItemType.Dropdown,
 );
 
-export const NavigationItem: React.FC<NavigationItemProps> = ({
+export const NavigationItem = ({
     data,
     className,
     menuLayout,
     ...props
-}: NavigationItemProps) => {
+}: React.PropsWithChildren<NavigationItemProps>) => {
     const {type = NavigationItemType.Link} = data;
     const navItemMap = useNavigationItemMap();
     const Component = navItemMap[type] as CustomItem;

--- a/src/navigation/components/NavigationItem/NavigationItem.tsx
+++ b/src/navigation/components/NavigationItem/NavigationItem.tsx
@@ -19,12 +19,7 @@ const nonComplexNavigationItemTypes = NavigationItemTypes.filter(
     (type) => type !== NavigationItemType.Dropdown,
 );
 
-export const NavigationItem = ({
-    data,
-    className,
-    menuLayout,
-    ...props
-}: React.PropsWithChildren<NavigationItemProps>) => {
+export const NavigationItem = ({data, className, menuLayout, ...props}: NavigationItemProps) => {
     const {type = NavigationItemType.Link} = data;
     const navItemMap = useNavigationItemMap();
     const Component = navItemMap[type] as CustomItem;

--- a/src/navigation/components/NavigationItem/components/ContentWrapper/ContentWrapper.tsx
+++ b/src/navigation/components/NavigationItem/components/ContentWrapper/ContentWrapper.tsx
@@ -14,7 +14,11 @@ interface ContentWrapperProps {
     iconSize?: number;
 }
 
-export const ContentWrapper: React.FC<ContentWrapperProps> = ({text, icon, iconSize}) => {
+export const ContentWrapper = ({
+    text,
+    icon,
+    iconSize,
+}: React.PropsWithChildren<ContentWrapperProps>) => {
     const iconSizeStyle = React.useMemo(
         () => (iconSize ? {height: `${iconSize}px`, width: `${iconSize}px`} : {}),
         [iconSize],

--- a/src/navigation/components/NavigationItem/components/ContentWrapper/ContentWrapper.tsx
+++ b/src/navigation/components/NavigationItem/components/ContentWrapper/ContentWrapper.tsx
@@ -14,11 +14,7 @@ interface ContentWrapperProps {
     iconSize?: number;
 }
 
-export const ContentWrapper = ({
-    text,
-    icon,
-    iconSize,
-}: React.PropsWithChildren<ContentWrapperProps>) => {
+export const ContentWrapper = ({text, icon, iconSize}: ContentWrapperProps) => {
     const iconSizeStyle = React.useMemo(
         () => (iconSize ? {height: `${iconSize}px`, width: `${iconSize}px`} : {}),
         [iconSize],

--- a/src/navigation/components/NavigationItem/components/NavigationButton/NavigationButton.tsx
+++ b/src/navigation/components/NavigationItem/components/NavigationButton/NavigationButton.tsx
@@ -14,7 +14,7 @@ const ANALYTICS_ID = 'navigation';
 
 type NavigationButtonProps = Pick<NavigationItemProps, 'className'> & ButtonProps;
 
-export const NavigationButton: React.FC<NavigationButtonProps> = (props) => {
+export const NavigationButton = (props: React.PropsWithChildren<NavigationButtonProps>) => {
     const {url, target, className} = props;
     const classes = b(null, className);
     return (

--- a/src/navigation/components/NavigationItem/components/NavigationButton/NavigationButton.tsx
+++ b/src/navigation/components/NavigationItem/components/NavigationButton/NavigationButton.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {Button, RouterLink} from '../../../../../components';
 import {BlockIdContext} from '../../../../../context/blockIdContext';
 import {ButtonProps} from '../../../../../models';
@@ -14,7 +12,7 @@ const ANALYTICS_ID = 'navigation';
 
 type NavigationButtonProps = Pick<NavigationItemProps, 'className'> & ButtonProps;
 
-export const NavigationButton = (props: React.PropsWithChildren<NavigationButtonProps>) => {
+export const NavigationButton = (props: NavigationButtonProps) => {
     const {url, target, className} = props;
     const classes = b(null, className);
     return (

--- a/src/navigation/components/NavigationItem/components/NavigationLink/NavigationLink.tsx
+++ b/src/navigation/components/NavigationItem/components/NavigationLink/NavigationLink.tsx
@@ -15,7 +15,7 @@ const b = block('navigation-link');
 
 type NavigationLinkProps = NavigationItemProps & NavigationLinkItem;
 
-export const NavigationLink: React.FC<NavigationLinkProps> = (props) => {
+export const NavigationLink = (props: React.PropsWithChildren<NavigationLinkProps>) => {
     const {hostname, Link} = React.useContext(LocationContext);
     const {url, text, icon, arrow, target, className, iconSize, urlTitle, ...rest} = props;
     const linkExtraProps = getLinkProps(url, hostname, target);

--- a/src/navigation/components/NavigationItem/components/NavigationLink/NavigationLink.tsx
+++ b/src/navigation/components/NavigationItem/components/NavigationLink/NavigationLink.tsx
@@ -15,7 +15,7 @@ const b = block('navigation-link');
 
 type NavigationLinkProps = NavigationItemProps & NavigationLinkItem;
 
-export const NavigationLink = (props: React.PropsWithChildren<NavigationLinkProps>) => {
+export const NavigationLink = (props: NavigationLinkProps) => {
     const {hostname, Link} = React.useContext(LocationContext);
     const {url, text, icon, arrow, target, className, iconSize, urlTitle, ...rest} = props;
     const linkExtraProps = getLinkProps(url, hostname, target);

--- a/src/navigation/components/NavigationList/NavigationList.tsx
+++ b/src/navigation/components/NavigationList/NavigationList.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import {NavigationListProps} from '../../models';
 import NavigationListItem from '../NavigationListItem/NavigationListItem';
 
-export const NavigationList: React.FC<NavigationListProps> = ({
+export const NavigationList = ({
     className,
     itemClassName,
     items,
     ...props
-}) => (
+}: React.PropsWithChildren<NavigationListProps>) => (
     <ul className={className}>
         {items.map((item, index) => (
             <NavigationListItem

--- a/src/navigation/components/NavigationList/NavigationList.tsx
+++ b/src/navigation/components/NavigationList/NavigationList.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {NavigationListProps} from '../../models';
 import NavigationListItem from '../NavigationListItem/NavigationListItem';
 
@@ -8,7 +6,7 @@ export const NavigationList = ({
     itemClassName,
     items,
     ...props
-}: React.PropsWithChildren<NavigationListProps>) => (
+}: NavigationListProps) => (
     <ul className={className}>
         {items.map((item, index) => (
             <NavigationListItem

--- a/src/navigation/components/NavigationListItem/NavigationListItem.tsx
+++ b/src/navigation/components/NavigationListItem/NavigationListItem.tsx
@@ -4,13 +4,13 @@ import {NavigationListItemProps} from '../../models';
 import {getItemClickHandler} from '../../utils';
 import NavigationItem from '../NavigationItem';
 
-export const NavigationListItem: React.FC<NavigationListItemProps> = ({
+export const NavigationListItem = ({
     column,
     index,
     activeItemId,
     onActiveItemChange,
     ...props
-}: NavigationListItemProps) => {
+}: React.PropsWithChildren<NavigationListItemProps>) => {
     const id = `${column}-${index}`;
     const isActive = id === activeItemId;
     const onClick = getItemClickHandler({

--- a/src/navigation/components/NavigationListItem/NavigationListItem.tsx
+++ b/src/navigation/components/NavigationListItem/NavigationListItem.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {NavigationListItemProps} from '../../models';
 import {getItemClickHandler} from '../../utils';
 import NavigationItem from '../NavigationItem';
@@ -10,7 +8,7 @@ export const NavigationListItem = ({
     activeItemId,
     onActiveItemChange,
     ...props
-}: React.PropsWithChildren<NavigationListItemProps>) => {
+}: NavigationListItemProps) => {
     const id = `${column}-${index}`;
     const isActive = id === activeItemId;
     const onClick = getItemClickHandler({

--- a/src/navigation/components/NavigationPopup/NavigationPopup.tsx
+++ b/src/navigation/components/NavigationPopup/NavigationPopup.tsx
@@ -11,12 +11,12 @@ import './NavigationPopup.scss';
 const b = block('navigation-popup');
 const OFFSET_RESET: {mainAxis?: number; crossAxis?: number} = {mainAxis: 0, crossAxis: 0};
 
-export const NavigationPopup: React.FC<NavigationPopupProps> = ({
+export const NavigationPopup = ({
     anchorRef,
     items,
     onClose,
     open,
-}) => {
+}: React.PropsWithChildren<NavigationPopupProps>) => {
     // Opening and closing is controlled by the associated button,
     // but in order to give the popup control over closing as well (e.g. on click outside or escape key press)
     // there needs to be an awkward looking handler like this.

--- a/src/navigation/components/NavigationPopup/NavigationPopup.tsx
+++ b/src/navigation/components/NavigationPopup/NavigationPopup.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {Popup} from '@gravity-ui/uikit';
 
 import {block} from '../../../utils';
@@ -11,12 +9,7 @@ import './NavigationPopup.scss';
 const b = block('navigation-popup');
 const OFFSET_RESET: {mainAxis?: number; crossAxis?: number} = {mainAxis: 0, crossAxis: 0};
 
-export const NavigationPopup = ({
-    anchorRef,
-    items,
-    onClose,
-    open,
-}: React.PropsWithChildren<NavigationPopupProps>) => {
+export const NavigationPopup = ({anchorRef, items, onClose, open}: NavigationPopupProps) => {
     // Opening and closing is controlled by the associated button,
     // but in order to give the popup control over closing as well (e.g. on click outside or escape key press)
     // there needs to be an awkward looking handler like this.

--- a/src/navigation/components/SocialIcon/SocialIcon.tsx
+++ b/src/navigation/components/SocialIcon/SocialIcon.tsx
@@ -13,7 +13,12 @@ export interface NavigationSocialItemOwnProps extends NavigationSocialItem {
     className?: string;
 }
 
-const SocialIcon: React.FC<NavigationSocialItemOwnProps> = ({icon, url, className, urlTitle}) => {
+const SocialIcon = ({
+    icon,
+    url,
+    className,
+    urlTitle,
+}: React.PropsWithChildren<NavigationSocialItemOwnProps>) => {
     const iconData = getMediaImage(icon);
     const {alt} = iconData;
 

--- a/src/navigation/components/SocialIcon/SocialIcon.tsx
+++ b/src/navigation/components/SocialIcon/SocialIcon.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {Image} from '../../../components';
 import {getMediaImage} from '../../../components/Media/Image/utils';
 import {NavigationSocialItem} from '../../../models';
@@ -13,12 +11,7 @@ export interface NavigationSocialItemOwnProps extends NavigationSocialItem {
     className?: string;
 }
 
-const SocialIcon = ({
-    icon,
-    url,
-    className,
-    urlTitle,
-}: React.PropsWithChildren<NavigationSocialItemOwnProps>) => {
+const SocialIcon = ({icon, url, className, urlTitle}: NavigationSocialItemOwnProps) => {
     const iconData = getMediaImage(icon);
     const {alt} = iconData;
 

--- a/src/navigation/containers/Layout/Layout.tsx
+++ b/src/navigation/containers/Layout/Layout.tsx
@@ -13,7 +13,7 @@ export interface LayoutProps {
     children?: React.ReactNode;
 }
 
-const Layout: React.FC<LayoutProps> = ({children, navigation}) => (
+const Layout = ({children, navigation}: React.PropsWithChildren<LayoutProps>) => (
     <div className={b()}>
         {navigation &&
             (navigation.renderNavigation ? (


### PR DESCRIPTION
Removed `React.PropsWithChildren` from those components where `children` was not relavant.