### PR TITLE
feat: added HeaderBlockFullProps to export

### DIFF
--- a/src/blocks/Header/Header.tsx
+++ b/src/blocks/Header/Header.tsx
@@ -18,7 +18,7 @@ import './Header.scss';
 
 const b = block('header-block');
 
-type HeaderBlockFullProps = HeaderBlockProps & ClassNameProps;
+export type HeaderBlockFullProps = HeaderBlockProps & ClassNameProps;
 
 interface BackgroundProps {
     background: HeaderBlockBackground;


### PR DESCRIPTION
Just changed:

```tsx
type HeaderBlockFullProps = HeaderBlockProps & ClassNameProps;
```

To 

```tsx
export type HeaderBlockFullProps = HeaderBlockProps & ClassNameProps;
```

So it is now exported.