### PR TITLE
fix: support compatible types for compound components

### DIFF
--- a/src/components/CardBase/CardBase.tsx
+++ b/src/components/CardBase/CardBase.tsx
@@ -39,9 +39,13 @@ export interface CardFooterBaseProps {
 
 const b = block('card-base-block');
 
-const Header: (props: React.PropsWithChildren<CardHeaderBaseProps>) => React.ReactNode = () => null;
-const Content: (props: React.PropsWithChildren<{}>) => React.ReactNode = () => null;
-const Footer: (props: React.PropsWithChildren<CardFooterBaseProps>) => React.ReactNode = () => null;
+const Header: (
+    props: React.PropsWithChildren<CardHeaderBaseProps>,
+) => React.ReactElement | null = () => null;
+const Content: (props: React.PropsWithChildren<{}>) => React.ReactElement | null = () => null;
+const Footer: (
+    props: React.PropsWithChildren<CardFooterBaseProps>,
+) => React.ReactElement | null = () => null;
 
 export const Layout = (props: CardBasePropsType) => {
     const {

--- a/src/components/MediaBase/MediaBase.tsx
+++ b/src/components/MediaBase/MediaBase.tsx
@@ -12,7 +12,7 @@ import './MediaBase.scss';
 
 const b = block('media-base');
 
-const Card: (props: React.PropsWithChildren<{}>) => React.ReactNode = () => null;
+const Card: (props: React.PropsWithChildren<{}>) => React.ReactElement | null = () => null;
 
 interface MediaBaseProps extends MediaBaseBlockProps {
     children: React.ReactElement;


### PR DESCRIPTION
Because of the differences between `React.ReactNode` in React version 18 and previous versions, type `React.ReactNode` does not pass typescript checks during use on a react versions below 18

Example:
<img width="1545" height="318" alt="2025-08-25_22-45-57" src="https://github.com/user-attachments/assets/39c42f0b-b842-4bfd-9717-f67baa1f2cbd" />

Fixed the type on `React.ReactElement` as more compatible
P.S. It seems that there are no internal type checks for children in these components, so this should not affect usage