### PR TITLE
fix(Header): restore background image on mobile devices

### DIFF
--- a/src/blocks/Header/Header.tsx
+++ b/src/blocks/Header/Header.tsx
@@ -38,7 +38,7 @@ interface BackgroundProps {
 const Background = ({background, isMobile}: BackgroundProps) => {
     const {url, image, fullWidthMedia, video, color} = background;
     const imageObject = url ? getMediaImage(url) : image;
-    const renderMedia = !isMobile || (typeof image === 'object' && 'mobile' in image);
+    const renderMedia = Boolean(imageObject);
 
     return (
         <div


### PR DESCRIPTION
Fixes [#1805 in `diplodoc-platform/client`](https://github.com/diplodoc-platform/cli/issues/1805) (or the corresponding issue in this repo).

The `renderMedia` condition in `Background` was preventing background images from appearing on mobile because `!isMobile` evaluated to `false`.  
Replaced the condition with `Boolean(imageObject)`, so a background image is shown whenever it's provided, regardless of screen size.