### PR TITLE
feat(deps): bump swiper to ^12.2.0 to fix prototype pollution (CVE-2026-27212)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-waypoint": "^10.1.0",
         "sanitize-html": "2.12.1",
         "snakecase-keys": "^5.1.0",
-        "swiper": "^10.2.0",
+        "swiper": "^12.2.0",
         "typograf": "^7.4.1",
         "utility-types": "^3.10.0",
         "uuid": "^9.0.0"
@@ -107,6 +107,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.16",
         "postcss-loader": "^4.3.0",
+        "postcss-nesting": "^12.1.5",
         "postcss-preset-env": "^9.0.0",
         "postcss-scss": "^4.0.4",
         "prettier": "^3.4.2",
@@ -27617,19 +27618,20 @@
       }
     },
     "node_modules/swiper": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-10.3.1.tgz",
-      "integrity": "sha512-24Wk3YUdZHxjc9faID97GTu6xnLNia+adMt6qMTZG/HgdSUt4fS0REsGUXJOgpTED0Amh/j+gRGQxsLayJUlBQ==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.2.0.tgz",
+      "integrity": "sha512-K8uXsBZU6ME97Ia3xbBge8IRCnR1lOmIILzvY/jGVic7dSTQ530s3uO8RvXbPUtkkXLWIwmZLRPbtDxRWVAFdg==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react-waypoint": "^10.1.0",
     "sanitize-html": "2.12.1",
     "snakecase-keys": "^5.1.0",
-    "swiper": "^10.2.0",
+    "swiper": "^12.2.0",
     "typograf": "^7.4.1",
     "utility-types": "^3.10.0",
     "uuid": "^9.0.0"
@@ -200,6 +200,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.16",
     "postcss-loader": "^4.3.0",
+    "postcss-nesting": "^12.1.5",
     "postcss-preset-env": "^9.0.0",
     "postcss-scss": "^4.0.4",
     "prettier": "^3.4.2",

--- a/widget.webpack.js
+++ b/widget.webpack.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 const autoprefixer = require('autoprefixer');
+const postcssNesting = require('postcss-nesting');
 const TerserPlugin = require('terser-webpack-plugin');
 
 const SRC_PATH = path.resolve('src');
@@ -10,6 +11,15 @@ const NODE_MODULES_PATH = path.resolve('node_modules');
 const WIDGET_SRC_PATH = path.resolve(SRC_PATH, 'widget');
 const WIDGET_RESULT_PATH = path.resolve(__dirname, 'widget');
 const WIDGET_BUNDLE_FILENAME = 'index.js';
+
+const STYLE_INCLUDE_PATHS = [
+    path.resolve(NODE_MODULES_PATH, '@diplodoc/transform'),
+    path.resolve(NODE_MODULES_PATH, '@gravity-ui/components'),
+    path.resolve(NODE_MODULES_PATH, '@gravity-ui/uikit'),
+    path.resolve(NODE_MODULES_PATH, 'swiper'),
+    path.resolve(__dirname, 'styles'),
+    SRC_PATH,
+];
 
 module.exports = {
     entry: {
@@ -31,15 +41,8 @@ module.exports = {
                 },
             },
             {
-                test: /\.(scss|css)$/,
-                include: [
-                    path.resolve(NODE_MODULES_PATH, '@diplodoc/transform'),
-                    path.resolve(NODE_MODULES_PATH, '@gravity-ui/components'),
-                    path.resolve(NODE_MODULES_PATH, '@gravity-ui/uikit'),
-                    path.resolve(NODE_MODULES_PATH, 'swiper'),
-                    path.resolve(__dirname, 'styles'),
-                    SRC_PATH,
-                ],
+                test: /\.scss$/,
+                include: STYLE_INCLUDE_PATHS,
                 use: [
                     'style-loader',
                     'css-loader',
@@ -51,6 +54,23 @@ module.exports = {
                     },
                     'resolve-url-loader',
                     'sass-loader',
+                ],
+            },
+            {
+                // Swiper 12+ (and other vendors) ship plain CSS that relies on
+                // native CSS nesting, which sass-loader cannot parse. Process
+                // plain CSS without sass-loader and flatten nesting via postcss.
+                test: /\.css$/,
+                include: STYLE_INCLUDE_PATHS,
+                use: [
+                    'style-loader',
+                    'css-loader',
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            postcssOptions: {plugins: [postcssNesting(), autoprefixer()]},
+                        },
+                    },
                 ],
             },
         ],


### PR DESCRIPTION
> 🤖 AI generated

## What

Bump `swiper` `^10.2.0` → `^12.2.0` to fix critical prototype pollution **CVE-2026-27212** (GHSA-hmx5-qpq5-p643), fixed in swiper 12.1.2. The `Slider` block (the only consumer) needs no source changes — import paths, props, and runtime classes are identical in v12.

## CSS nesting

Swiper 12 ships its CSS using **native CSS nesting** (`&`), which `sass-loader` cannot parse. Consumers must build with a bundler that supports CSS nesting (true for any swiper 12 user). The bundled widget build is updated accordingly: plain vendor `.css` is now handled by `css-loader` + `postcss-nesting` instead of the SCSS pipeline, and `postcss-nesting` is added as an explicit devDependency. Output for non-swiper vendor CSS is unchanged.

## Verification

typecheck, lint, unit tests (222), and full build (client/server/widget/schema, incl. CJS swiper interop) pass; Slider visual tests pass (chromium all, webkit all that ran); `npm audit` no longer flags swiper.