### PR TITLE
fix(styles): use semantic shadow token for card shadows

### DIFF
--- a/styles/root.scss
+++ b/styles/root.scss
@@ -16,7 +16,7 @@
     --pc-border-radius: 24px;
     --pc-image-padding: 4px;
 
-    --pc-color-sfx-shadow: var(--g-color-base-simple-hover);
+    --pc-color-sfx-shadow: var(--g-color-sfx-shadow-light);
     --pc-color-line-generic-active-solid: #b3b3b3;
     --pc-color-base-float-hover: var(--g-color-base-float);
     --pc-monochrome-button-background-color: #262626;
@@ -50,7 +50,6 @@
     }
 
     &.g-root_theme_dark {
-        --pc-color-sfx-shadow: var(--g-color-sfx-shadow);
         --pc-color-line-generic-active-solid: #6c6c70;
         --pc-color-base-float-hover: var(--g-color-base-float-hover);
         --pc-monochrome-button-background-color: #ffffff;


### PR DESCRIPTION
Card shadows currently depend on the UIKit hover-background token in the light theme. Use the semantic `--g-color-sfx-shadow-light` token for `--pc-color-sfx-shadow` and remove its separate dark-theme override.

Standard light and dark shadow colors remain unchanged. No package version or dependency changes are needed.

Validation: lint, typecheck, unit tests, Playwright component tests, and preview builds passed in the [fork validation PR](https://github.com/Alexey-UI/page-constructor/pull/1). Additional Chromium/WebKit checks confirmed unchanged light/dark rendering, including hover, and correct behavior when customizing shadow and hover-background tokens.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.
